### PR TITLE
Use by default the yamler syck

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-
 # Set up gems listed in the Gemfile.
 gemfile = File.expand_path('../../Gemfile', __FILE__)
 begin
@@ -11,3 +10,4 @@ rescue Bundler::GemNotFound => e
   STDERR.puts "Try running `bundle install`."
   exit!
 end if File.exist?(gemfile)
+YAML::ENGINE.yamler= 'syck' 


### PR DESCRIPTION
Added the default yamler=syck for fix the 'YAML: Parser error' when run the project.
