### PR TITLE
Fix some minor bug.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,9 +58,13 @@ class ProjectsController < ApplicationController
     params[:project][:expires_at] += (23.hours + 59.minutes + 59.seconds) if params[:project][:expires_at]
     validate_rewards_attributes if params[:project][:rewards_attributes].present?
     create!(:notice => t('projects.create.success'))
-    @project.reload
-    @project.update_attribute :short_url, bitly
-    @project.projects_sites.create :site => current_site
+    # When don't create the project the @project don't exists so causes a record not found
+    # because @project.reload *words only with created records*
+    unless @project.new_record?
+      @project.reload
+      @project.update_attribute :short_url, bitly
+      @project.projects_sites.create :site => current_site
+    end
   end
   def show
     show!{


### PR DESCRIPTION
When i sent the project without some reward informations its raise a not found exception because its call -> @project.reload but the @project is new_record yet, so I create the validate_rewards_attributes for validate the rewards attributes in params hash and added the condition @project.new_record? to verify the project, when is a new_project don't call the reload if not call.

[]'s 
