### PR TITLE
Add host to airbrake config

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,4 @@
 Airbrake.configure do |config|
-  config.api_key = Configuration[:airbrake_key]
+  config.api_key = Configuration[:airbrake_key] if Configuration[:airbrake_key].present?
+  config.host    = Configuration[:airbrake_host] if Configuration[:airbrake_host].present?
 end


### PR DESCRIPTION
This way we can also use self hosted installations of airbrake
api compatible applications (like errbit).
