### PR TITLE
Was this maybe suposed to be temporary?

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register Project do
 
   form do |f|
     f.inputs do
-      # f.input :user
+      f.input :user
       f.input :category
       f.input :curated_pages
       f.input :name, :as => :string


### PR DESCRIPTION
I can not create a Project in the admin without it, the validation fails and comes back with no error messages. 
