### PR TITLE
Fix i18n parse errors with locale files (en/pt)

### DIFF
--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,7 @@
 pt:
+  no: "Não"
+  yes: "Sim"
+  or: "ou"
   backer_report_to_project_owner:
     reward_description: 'Descrição da recompensa'
     confirmed_at: 'Data da confirmação do pagamento'
@@ -22,7 +25,6 @@ pt:
         notice: 'Recompensa adicionada com sucesso!'
         alert: 'Ops! não foi possível adicionar a recompensa.'
   facebook_locale: 'pt_BR'
-  or: ou
   newsletter_ok_header: "Cadastro efetuado!"
   newsletter_ok_body: "Seu email foi cadastrado com sucesso, obrigado!"
   newsletter_error_header: "Ooops! Ocorreu um erro."
@@ -89,8 +91,6 @@ pt:
       title: "novos e fresquinhos"
     partners:
       title: parceiros
-  "no": Não
-  "yes": Sim
   accept_terms_html: "Eu li e estou de acordo com os %{link}."
   activerecord:
     errors:
@@ -469,7 +469,7 @@ pt:
     show:
       rejected: "Este projeto não foi selecionado para participar do Catarse. Quem sabe numa próxima vez? :)"
       waiting: "Esse projeto está em fase de rascunho e logo saberemos se ele entrará no Catarse. Se está vendo o projeto, e não é o dono dele... aproveita para mandar sua opinião ao realizador."
-      waiting_owner: "<i>ATENÇÃO! Seu projeto ainda não está no ar... Seja bem-vindo ao rascunho \o/ </i><br><br>Esse é o espaço para você construir seu projeto. <br>Nenhuma informação abaixo é definitiva até a entrada do seu projeto no ar. Por isso, aproveite! <br><br>Para editar as informações da página do projeto, basta clicar em EDIÇÃO. <br>As recompensas você edita na coluna delas mesmo :D <br>Compartilhe com seus amigos e colha sugestões.<br><br><b>Lembrando que:</b> O Catarse é uma plataforma curada, o que significa que vamos avaliar o foco, a viabilidade, e a consistência do seu projeto durante o processo de Rascunho. Se entendermos que o seu projeto não está de acordo com os nossos <a href='http://docs.google.com/document/d/1Heh9LlvoSoD0lUfbmV5WlISJ3nqmGpEQiw15TBuCn-0/edit' target='_blank'>Critérios de Seleção</a>, ele poderá ser recusado pela equipe de curadores."
+      waiting_owner: "<i>ATENÇÃO! Seu projeto ainda não está no ar... Seja bem-vindo ao rascunho! </i><br><br>Esse é o espaço para você construir seu projeto. <br>Nenhuma informação abaixo é definitiva até a entrada do seu projeto no ar. Por isso, aproveite! <br><br>Para editar as informações da página do projeto, basta clicar em EDIÇÃO. <br>As recompensas você edita na coluna delas mesmo :D <br>Compartilhe com seus amigos e colha sugestões.<br><br><b>Lembrando que:</b> O Catarse é uma plataforma curada, o que significa que vamos avaliar o foco, a viabilidade, e a consistência do seu projeto durante o processo de Rascunho. Se entendermos que o seu projeto não está de acordo com os nossos <a href='http://docs.google.com/document/d/1Heh9LlvoSoD0lUfbmV5WlISJ3nqmGpEQiw15TBuCn-0/edit' target='_blank'>Critérios de Seleção</a>, ele poderá ser recusado pela equipe de curadores."
       about_title: "O projeto"
       no_rewards_warning_title: 'Crie aqui suas recompensas'
       no_rewards_warning: 'Não viaje! Pense em como irá entregá-las e coloque tudo isso no orçamento. Prometeu?! CUMPRA! :D'

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -1,177 +1,175 @@
 en:
   date:
     abbr_day_names:
-      - Sun
-      - Mon
-      - Tue
-      - Wed
-      - Thu
-      - Fri
-      - Sat
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
     abbr_month_names:
-      - ~
-      - Jan
-      - Feb
-      - Mar
-      - Apr
-      - May
-      - Jun
-      - Jul
-      - Aug
-      - Sep
-      - Oct
-      - Nov
-      - Dec
+    - 
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
     day_names:
-      - Sunday
-      - Monday
-      - Tuesday
-      - Wednesday
-      - Thursday
-      - Friday
-      - Saturday
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
     formats:
-      default: "%d/%m/%Y"
-      long: %B "%d  %Y"
-      short: %B "%d"
+      default: ! '%Y-%m-%d'
+      long: ! '%B %d, %Y'
+      short: ! '%b %d'
     month_names:
-      - 
-      - January
-      - February
-      - March
-      - April
-      - May
-      - June
-      - July
-      - August
-      - September
-      - October
-      - November
-      - December
+    - 
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
     order:
-      - :month
-      - :day
-      - :year
+    - :year
+    - :month
+    - :day
   datetime:
     distance_in_words:
       about_x_hours:
-        one: "approximately 1 hour"
-        other: "approximately %{count} hours"
+        one: about 1 hour
+        other: about %{count} hours
       about_x_months:
-        one: "approximately 1 month"
-        other: "approximately %{count} months"
+        one: about 1 month
+        other: about %{count} months
       about_x_years:
-        one: "approximately 1 year"
-        other: "approximately %{count} years"
+        one: about 1 year
+        other: about %{count} years
       almost_x_years:
-        one: "almost 1 ano"
-        other: "almost %{count} years"
-      half_a_minute: "thirty seconds"
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
       less_than_x_minutes:
-        one: "less than a minute"
-        other: "less than %{count} minutes"
+        one: less than a minute
+        other: less than %{count} minutes
       less_than_x_seconds:
-        one: "less than 1 segundo"
-        other: "less than %{count} seconds"
+        one: less than 1 second
+        other: less than %{count} seconds
       over_x_years:
-        one: "more than 1 year"
-        other: "more than %{count} years"
+        one: over 1 year
+        other: over %{count} years
       x_days:
-        one: "1 day"
-        other: "%{count} days"
+        one: 1 day
+        other: ! '%{count} days'
       x_minutes:
-        one: "1 minute"
-        other: "%{count} minutes"
+        one: 1 minute
+        other: ! '%{count} minutes'
       x_months:
-        one: "1 mês"
-        other: "%{count} months"
+        one: 1 month
+        other: ! '%{count} months'
       x_seconds:
-        one: "1 segundo"
-        other: "%{count} seconds"
+        one: 1 second
+        other: ! '%{count} seconds'
     prompts:
       day: Day
       hour: Hour
       minute: Minute
       month: Month
-      second: Second
+      second: Seconds
       year: Year
   errors: &errors
-    format: "%{attribute} %{message}"
+    format: ! '%{attribute} %{message}'
     messages:
-      accepted: "must be accepted"
-      blank: "cannot be blank"
-      confirmation: "doesn't match"
-      empty: "cannot be empty"
-      equal_to: "must equal %{count}"
-      even: "must be even"
-      exclusion: "not available"
-      greater_than: "must be greater than %{count}"
-      greater_than_or_equal_to: "must be greater than or equal to %{count}"
-      inclusion: "is not included in the list"
-      invalid: "isn't valid"
-      less_than: "must be less than %{count}"
-      less_than_or_equal_to: "must be less than or equal to %{count}"
-      not_a_number: "not a number"
-      not_an_integer: "isn't an integer"
-      odd: "must be odd"
-      record_invalid: "validation failed: %{errors}"
-      taken: "is already taken"
-      too_long: "is too long (max: %{count} characters)"
-      too_short: "is too short (min: %{count} characters)"
-      wrong_length: "isn't the expected size (%{count} characters)"
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match confirmation
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      record_invalid: ! 'Validation failed: %{errors}'
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
     template:
-      body: "Please check the following fields:"
+      body: ! 'There were problems with the following fields:'
       header:
-        one: "Couldn't write %{model}: 1 error"
-        other: "Couldn't write %{model}: %{count} errors."
+        one: 1 error prohibited this %{model} from being saved
+        other: ! '%{count} errors prohibited this %{model} from being saved'
   helpers:
     select:
-      prompt: "Please select"
+      prompt: Please select
     submit:
-      create: "Create %{model}"
-      submit: "Submit %{model}"
-      update: "Update %{model}"
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
   number:
     currency:
       format:
-        delimiter: ","
-        format: "%u %n"
+        delimiter: ! ','
+        format: ! '%u%n'
         precision: 2
-        separator: "."
+        separator: .
         significant: false
         strip_insignificant_zeros: false
-        unit: R$
+        unit: $
     format:
-      delimiter: "."
+      delimiter: ! ','
       precision: 3
-      separator: ","
+      separator: .
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: "%n %u"
+        format: ! '%n %u'
         units:
-          billion:
-            one: billion
-            other: billion
-          million:
-            one: million
-            other: million
-          quadrillion:
-            one: quadrillion
-            other: quadrillion
-          thousand: thousand
-          trillion:
-            one: trillion
-            other: trillion
-          unit: ~
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
       format:
-        delimiter: "."
-        precision: 2
+        delimiter: ''
+        precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: "%n %u"
+        format: ! '%n %u'
         units:
           byte:
             one: Byte
@@ -182,28 +180,27 @@ en:
           tb: TB
     percentage:
       format:
-        delimiter: "."
+        delimiter: ''
     precision:
       format:
-        delimiter: "."
+        delimiter: ''
   support:
     array:
-      last_word_connector: " e "
-      two_words_connector: " e "
-      words_connector: ", "
+      last_word_connector: ! ', and '
+      two_words_connector: ! ' and '
+      words_connector: ! ', '
   time:
     am: am
     formats:
-      simple: "%m/%d/%Y, %H:%M h"
-      default: "%A, %d de %B de %Y, %H:%M h"
-      long: "%A, %d de %B de %Y, %H:%M h"
-      short: "%m/%d, %H:%M h"
-      updates: "%d %b %Y"
+      default: ! '%a, %d %b %Y %H:%M:%S %z'
+      long: ! '%B %d, %Y %H:%M'
+      short: ! '%d %b %H:%M'
     pm: pm
   # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
-    activemodel:
-      errors:
-        <<: *errors
-    activerecord:
-      errors:
-        <<: *errors
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors
+


### PR DESCRIPTION
While running bundle install on Rails 3.2.12, I was facing a strange error on i18n gem. 

On the `config/locales/en.yml` file, some lines were missing the `!` character ( I took the translation file from here: https://raw.github.com/svenfuchs/rails-i18n/master/rails/locale/en.yml 

On the `config/locales/pt.yml` the **line 472**, attribute `waiting_owner`, the character `\o/` was creating the following exception:

``` bash

➜  /vagrant git:(master) ✗ rake db:migrate db:test:prepare --trace
The source :gemcutter is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
** Invoke db:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
can not load translations from /vagrant/config/locales/pt.yml, expected it to return a hash, but does not
/usr/local/rvm/gems/ruby-1.9.3-p392/gems/i18n-0.6.1/lib/i18n/backend/base.rb:158:in `load_file'
/usr/local/rvm/gems/ruby-1.9.3-p392/gems/i18n-0.6.1/lib/i18n/backend/base.rb:15:in `block in load_translations'


```

**Screen here:**

![Screen Shot 2013-02-25 at 5 13 55 PM](https://f.cloud.github.com/assets/249782/193601/5bcf33cc-7f8a-11e2-9feb-ac9eb15d4dcd.png)

I removed the char, and everything is OK. I think it's because it was escaping the `\o`, not sure tho.

Thanks!
