### PR TITLE
Use partial local

### DIFF
--- a/app/views/projects/_project_header.html.slim
+++ b/app/views/projects/_project_header.html.slim
@@ -1,5 +1,5 @@
 .video_sample
-  iframe src="#{@project.video_embed_url}" width="461" height="258" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen
+  iframe src="#{project.video_embed_url}" width="461" height="258" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen
 .info
   h3= title
   h2


### PR DESCRIPTION
@project causes video_embed_url call on nil when the recommended_header partial is used.

Currently the channels banner is shown instead so this bug is not apparent by default.
