### PR TITLE
added task rake db:seed to execute multiple custom seeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ db/structure.sql
 .sass-cache
 Cookbooks
 .vagrant
+.project

--- a/db/seeds/my-seeds.rb
+++ b/db/seeds/my-seeds.rb
@@ -1,0 +1,47 @@
+## Optional Seed file 
+## to be used during development
+
+puts "Adding Uservoice.com settings..."
+
+  Configuration.find_or_create_by_name('uservoice_subdomain').update_attribute('value', 'dummy_domain.uservoice.com')  
+  Configuration.find_or_create_by_name('uservoice_sso_key').update_attribute('value', 'dummy_uservoice_sso_key')
+
+
+puts "Adding Admin user..."
+
+  User.find_or_create_by_name!(
+    name: "Admin",
+    nickname: "Admin",
+    email: "admin@admin.com",
+    nickname: "Admin",
+    password: "password",
+    password_confirmation: "password",
+    remember_me: false,
+    admin: true
+  )
+  
+puts "Adding Funder user..."
+
+  User.find_or_create_by_name!(
+    name: "Funder",
+    nickname: "Funder",
+    email: "funder@funder.com",
+    nickname: "Funder",
+    password: "password",
+    password_confirmation: "password",
+    remember_me: false
+  )
+
+puts "Adding Test user..."
+
+  User.find_or_create_by_name!(
+    name: "Test",
+    nickname: "Test",
+    email: "test@test.com",
+    nickname: "Test",
+    password: "password",
+    password_confirmation: "password",
+    remember_me: false
+  )
+
+puts "Done!"

--- a/lib/tasks/db_seed.rake
+++ b/lib/tasks/db_seed.rake
@@ -1,0 +1,15 @@
+####
+#This will allow you to do rake db:seed:x 
+#where “x” is a file in the db/seeds directory
+##
+namespace :db do
+  namespace :seed do
+    Dir[File.join(Rails.root, 'db', 'seeds', '*.rb')].each do |seed_file|
+      task_name = File.basename(seed_file, '.rb').intern    
+      desc "Load the seed data from db/seeds/#{task_name}.rb"
+      task task_name => :environment do
+        load(seed_file) if File.exist?(seed_file)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added rake task to execute multiple custom seeds that can be used for different environments / development runtime

```
Usage:
$ rake db:seed:{FILENAME AT /db/seeds}

Eg:
$ rake db:seed:my-seeds
```

my-seeds.rb file 
- fixes problems with uservoice_subdomain @ https://github.com/catarse/catarse/issues/166
- creates default users
