### PR TITLE
Add tabindex on email and password fields

### DIFF
--- a/app/views/catarse_bootstrap/devise/sessions/new.html.slim
+++ b/app/views/catarse_bootstrap/devise/sessions/new.html.slim
@@ -23,12 +23,12 @@
           = render 'devise/shared/alert'
           p
             = f.label :email
-            = f.text_field :email, class: [:login, :email], required: true, type: :email
+            = f.text_field :email, class: [:login, :email], required: true, type: :email, tabindex: 1
 
           p
             = f.label :password
             = link_to t('pages.login.links.forgot_password'), new_password_path(resource_name), class: 'right text-right'
-            = f.password_field :password, class: [:login], required: true
+            = f.password_field :password, class: [:login], required: true, tabindex: 2
           .text-left
             = f.check_box :remember_me, checked: true
             = f.label :remember_me, t('pages.login.form.labels.remember_me')


### PR DESCRIPTION
At the new login page we have the 'I forgot my password' link between email and password field, so, when I write my email I just press tab and start typing my password. But the focus is on link and not on the password field.

So, this pull fix that.
