### PR TITLE
Add return false to dropdown link

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -42,6 +42,7 @@ var App = window.App = Skull.View.extend({
 
   toggleMenu: function(){
     this.$dropdown.slideToggle('fast');
+    return false;
   }
 });
 


### PR DESCRIPTION
There is the '#' on dropdown link, and when we click is added that to url. Also if you are not on the top, the page jump to the top.
