### PR TITLE
prevent long urls from breaking out of container in project/about

### DIFF
--- a/app/assets/stylesheets/resources/projects/_show.sass
+++ b/app/assets/stylesheets/resources/projects/_show.sass
@@ -177,6 +177,7 @@
           strong
             font-weight: bold
           a
+            word-wrap: break-word
             color: $pink
             text-decoration: none
             &:hover


### PR DESCRIPTION
example: http://catarse.me/pt/larissario2016
