### PR TITLE
use notice.present? to prevent to show up blank string notices [Fix #595...

### DIFF
--- a/app/views/catarse_bootstrap/layouts/catarse_bootstrap.html.slim
+++ b/app/views/catarse_bootstrap/layouts/catarse_bootstrap.html.slim
@@ -24,7 +24,7 @@ html
 
   body#catarse_bootstrap[data-namespace=namespace data-controller-name=controller_name data-action=action_name]
     = render 'layouts/uservoice'
-    = render 'layouts/catarse_bootstrap_notices' if notice
+    = render 'layouts/catarse_bootstrap_notices' if notice.present?
     = render 'layouts/login_feedback_support' if devise_controller?
 
     .content= yield


### PR DESCRIPTION
...13140]
