### PR TITLE
Now we don't use html5 validation when browser is safari. The default ra...

### DIFF
--- a/app/views/catarse_bootstrap/devise/sessions/new.html.slim
+++ b/app/views/catarse_bootstrap/devise/sessions/new.html.slim
@@ -19,7 +19,7 @@
       .clearfix
 
       .large-11.large-centered.columns
-        = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+        = form_for(resource, as: resource_name, url: session_path(resource_name), html:{novalidate: browser.safari?}) do |f|
           = render 'devise/shared/alert'
           p
             = f.label :email


### PR DESCRIPTION
...ils validation works well in this case [fix #58633392]
