### PR TITLE
Add conditional to oauth_providers on devise initializer (solve #359)

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -215,8 +215,10 @@ Devise.setup do |config|
     config.omniauth 'facebook', 'dummy_key', 'dummy_secret', scope: ''
   else
     begin
-      OauthProvider.all.each do |p|
-        config.omniauth p.name, p.key, p.secret, scope: p.scope
+      if ActiveRecord::Base.connection.table_exists? 'oauth_providers'
+        OauthProvider.all.each do |p|
+          config.omniauth p.name, p.key, p.secret, scope: p.scope
+        end
       end
     rescue Exception => e
       puts "problem while using OauthProvider model:\n '#{e.message}'"


### PR DESCRIPTION
When you are trying to run the `rake db:migrate` from a empty database, the rescue that is there, is not working. So I add a conditional to see if the table exist before using it.
