### PR TITLE
video embeds now work instead of showing a route error

### DIFF
--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -39,7 +39,7 @@ class ProjectDecorator < Draper::Decorator
 
   def display_video_embed_url
     if source.video_embed_url
-      "//#{source.video_embed_url}?title=0&byline=0&portrait=0&autoplay=0"
+      "http://#{source.video_embed_url}?title=0&byline=0&portrait=0&autoplay=0"
     end
   end
 


### PR DESCRIPTION
Fixed this, it wasn't working when i was hosting it
