### PR TITLE
Change instruction for copying the database.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The official repo is https://github.com/catarse/catarse
 ```bash
 $ git clone https://github.com/catarse/catarse.git
 $ cd catarse
-$ mv config/database.sample.yml config/database.yml
+$ cp config/database.sample.yml config/database.yml
 $ vim config/database.yml 
 # change username/password and save
 $ bundle install


### PR DESCRIPTION
You should not move the config/database.sample.yml because it is on version control and database.yml is ignored.
