### PR TITLE
created migrations to add some timestamps missing in past projects

### DIFF
--- a/db/migrate/20140310200601_fix_missing_rejected_at.rb
+++ b/db/migrate/20140310200601_fix_missing_rejected_at.rb
@@ -1,0 +1,10 @@
+class FixMissingRejectedAt < ActiveRecord::Migration
+  def up
+    execute "
+    UPDATE projects SET rejected_at = updated_at WHERE rejected_at IS NULL AND state = 'rejected';
+    "
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20140310201238_fix_missing_sent_to_analysis_at.rb
+++ b/db/migrate/20140310201238_fix_missing_sent_to_analysis_at.rb
@@ -1,0 +1,10 @@
+class FixMissingSentToAnalysisAt < ActiveRecord::Migration
+  def up
+    execute "
+    UPDATE projects SET sent_to_analysis_at = created_at WHERE sent_to_analysis_at IS NULL AND state <> 'draft';
+    "
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Just setting timestamps in old projects based on two assumptions:
- For the rejected projects we can use the last update as the rejected_at date
- For the projects that are not on draft we can use the creation timestamp as the sent_to_analysis_at  
