### PR TITLE
use confirmed contribution to send payment methods things and back with ...

### DIFF
--- a/app/assets/javascripts/app/mix_panel.js
+++ b/app/assets/javascripts/app/mix_panel.js
@@ -24,6 +24,7 @@ App.addChild('MixPanel', {
     var self = this;
     this.trackPageVisit('projects', 'show', 'Visited project page');
     this.trackPageVisit('explore', 'index', 'Explored projects');
+    this.trackPageLoad('contributions', 'show', 'Finished contribution');
     this.trackPageLoad('contributions', 'edit', 'Selected reward');
   },
 

--- a/app/observers/mixpanel_observer.rb
+++ b/app/observers/mixpanel_observer.rb
@@ -2,14 +2,8 @@ class MixpanelObserver < ActiveRecord::Observer
   observe :contribution
 
   def from_waiting_confirmation_to_confirmed(contribution)
-    tracker.track(contribution.user.id.to_s, "Contribution confirmed")
-  end
-  alias :from_pending_to_confirmed :from_waiting_confirmation_to_confirmed
-
-  def from_pending_to_waiting_confirmation(contribution)
     user = contribution.user
-
-    tracker.track(user.id.to_s, "Finished contribution", {
+    tracker.track(contribution.user.id.to_s, "Contribution confirmed", {
       user_id: user.id.to_s,
       created: user.created_at,
       last_login: user.last_sign_in_at,
@@ -20,6 +14,7 @@ class MixpanelObserver < ActiveRecord::Observer
       payment_choice: contribution.payment_choice
     })
   end
+  alias :from_pending_to_confirmed :from_waiting_confirmation_to_confirmed
 
   private
   def tracker

--- a/spec/observers/mixpanel_observer_spec.rb
+++ b/spec/observers/mixpanel_observer_spec.rb
@@ -11,21 +11,7 @@ describe MixpanelObserver do
 
   describe "#from_waiting_confirmation_to_confirmed" do
     it "should send tracker a track call with the user id of the contribution" do
-      tracker.should_receive(:track).with(contribution.user.id.to_s, "Contribution confirmed")
-      contribution.notify_observers :from_waiting_confirmation_to_confirmed
-    end
-  end
-
-  describe "#from_pending_to_confirmed" do
-    it "should send tracker a track call with the user id of the contribution" do
-      tracker.should_receive(:track).with(contribution.user.id.to_s, "Contribution confirmed")
-      contribution.notify_observers :from_pending_to_confirmed
-    end
-  end
-
-  describe "#from_pending_to_waiting_confirmation" do
-    it "should send tracker a track call with the user id of the contribution" do
-      tracker.should_receive(:track).with(contribution.user.id.to_s, "Finished contribution", {
+      tracker.should_receive(:track).with(contribution.user.id.to_s, "Contribution confirmed", {
         user_id: contribution.user.id.to_s,
         created: contribution.user.created_at,
         last_login: contribution.user.last_sign_in_at,
@@ -35,9 +21,26 @@ describe MixpanelObserver do
         payment_method: contribution.payment_method,
         payment_choice: contribution.payment_choice
       })
-      contribution.notify_observers :from_pending_to_waiting_confirmation
+      contribution.notify_observers :from_waiting_confirmation_to_confirmed
     end
   end
+
+  describe "#from_pending_to_confirmed" do
+    it "should send tracker a track call with the user id of the contribution" do
+      tracker.should_receive(:track).with(contribution.user.id.to_s, "Contribution confirmed", {
+        user_id: contribution.user.id.to_s,
+        created: contribution.user.created_at,
+        last_login: contribution.user.last_sign_in_at,
+        contributions: contribution.user.total_contributed_projects,
+        has_contributions: (contribution.user.total_contributed_projects > 0),
+        project: contribution.project.name,
+        payment_method: contribution.payment_method,
+        payment_choice: contribution.payment_choice
+      })
+      contribution.notify_observers :from_pending_to_confirmed
+    end
+  end
+
 end
 
 


### PR DESCRIPTION
...the finished contribution to client side because the system skips when payments is made with credit card on mixpanel
