### PR TITLE
remove href='' because we already use defined?(href) to check if href is...

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -39,7 +39,7 @@ footer.footer
         .twitter-box
           = link_to "Follow @#{CatarseSettings[:twitter_username]}", "http://twitter.com/#{CatarseSettings[:twitter_username]}", :class => 'twitter-follow-button', :"data-button"=>"blue", :"data-text-color" => "#ffffff", :"data-link-color"=>"#fffffff", :"data-width" => "224px"
         .facebook-box
-          = render_facebook_like href: "", colorscheme: "dark", width: "171"
+          = render_facebook_like colorscheme: "dark", width: "171"
     hr
     .row
         p.copyleft= "#{t('.texts.copyleft')} Catarse, 2013 | Open source #{link_to 'Catarse @ Github', "#{CatarseSettings[:github_url]}", :class => 'github', target: '_blank'}".html_safe


### PR DESCRIPTION
... valid
