### PR TITLE
This .includes was not being used anymore, the counts from rewards/index...

### DIFF
--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -42,10 +42,6 @@ class RewardsController < ApplicationController
   end
 
   private
-  def collection
-    @rewards ||= parent.rewards.includes(:contributions)
-  end
-
   def permitted_params
     params.permit(policy(resource).permitted_attributes)
   end


### PR DESCRIPTION
... where going directly to the database. So we got 200ms of extra DB work for nothing.

And I should point out that this optimization is based on data from new relic, we are really spending a lot of unnecessary time rendering that template.
