### PR TITLE
Notification worker

### DIFF
--- a/app/models/project_post.rb
+++ b/app/models/project_post.rb
@@ -22,10 +22,6 @@ class ProjectPost < ActiveRecord::Base
     catarse_email_auto_html_for comment, image_width: 513
   end
 
-  def notify_contributors
-    ProjectPostWorker.perform_async(project)
-  end
-
   def to_partial_path
     "projects/posts/project_post"
   end

--- a/app/observers/project_post_observer.rb
+++ b/app/observers/project_post_observer.rb
@@ -2,6 +2,6 @@ class ProjectPostObserver < ActiveRecord::Observer
   observe :project_post
 
   def after_create(post)
-    post.notify_contributors
+    ProjectPostWorker.perform_async(post.id)
   end
 end

--- a/app/workers/project_post_worker.rb
+++ b/app/workers/project_post_worker.rb
@@ -2,9 +2,10 @@ class ProjectPostWorker
   include Sidekiq::Worker
   sidekiq_options retry: false
 
-  def perform project
-    project.subscribed_users.find_each do |user|
-      notify_once(:posts, user, project.project_post, {from_email: project.user.email, from_name: project.user.display_name})
+  def perform post_id
+    post = ProjectPost.find post_id
+    post.project.subscribed_users.each do |user|
+      post.notify_once(:posts, user, post, {from_email: post.project.user.email, from_name: post.project.user.display_name})
     end
   end
 end

--- a/spec/models/project_post_spec.rb
+++ b/spec/models/project_post_spec.rb
@@ -36,27 +36,4 @@ describe ProjectPost do
     it{ should == "<p>this is a comment<br />\n<a href=\"http://vimeo.com/6944344\" target=\"_blank\">http://vimeo.com/6944344</a><br />\n<img src=\"http://catarse.me/assets/catarse/logo164x54.png\" alt=\"\" style=\"max-width:513px\" /></p>" }
   end
 
-  describe "#notify_contributors" do
-    before do
-      @project = create(:project)
-      contribution = create(:contribution, state: 'confirmed', project: @project)
-      create(:contribution, state: 'confirmed', project: @project, user: contribution.user)
-      @project.reload
-      ActionMailer::Base.deliveries = []
-      @post = ProjectPost.create!(user: @project.user, project: @project, title: "title", comment: "this is a comment\nhttp://vimeo.com/6944344\nhttp://catarse.me/assets/catarse/logo164x54.png")
-      ProjectPostNotification.should_receive(:notify_once).with(
-        :posts,
-        contribution.user,
-        @post,
-        {
-          from_email: @post.project.user.email,
-          from_name: @post.project.user.display_name
-        }
-      ).once.and_call_original
-    end
-
-    it 'should call Notification.notify once' do
-      @post.notify_contributors
-    end
-  end
 end

--- a/spec/observers/project_post_observer_spec.rb
+++ b/spec/observers/project_post_observer_spec.rb
@@ -4,10 +4,10 @@ describe ProjectPostObserver do
   describe 'after_create' do
     context "notify contributions" do
       let(:project) { create(:project) }
-      let(:project_post) { build(:project_post) }
+      let(:project_post) { create(:project_post) }
 
       it "should satisfy expectations" do
-        project_post.should_receive(:notify_contributors)
+        ProjectPostWorker.should_receive(:perform_async).with(project_post.id)
         project_post.save
       end
     end

--- a/spec/workers/project_post_worker_spec.rb
+++ b/spec/workers/project_post_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe ProjectPostWorker do
+  let(:perform_post) { ProjectPostWorker.perform_async(@post.id) }
+
+  before do
+    Sidekiq::Testing.inline!
+    @project = create(:project)
+    contribution = create(:contribution, state: 'confirmed', project: @project)
+    create(:contribution, state: 'confirmed', project: @project, user: contribution.user)
+    @project.reload
+    ActionMailer::Base.deliveries = []
+    @post = ProjectPost.create!(user: @project.user, project: @project, title: "title", comment: "this is a comment\nhttp://vimeo.com/6944344\nhttp://catarse.me/assets/catarse/logo164x54.png")
+    ProjectPostNotification.should_receive(:notify_once).with(
+        :posts,
+        contribution.user,
+        @post,
+        {
+          from_email: @post.project.user.email,
+          from_name: @post.project.user.display_name
+        }
+      ).once.and_call_original
+  end
+
+  it("should satisfy expectations") { perform_post }
+end


### PR DESCRIPTION
Projects with lots of backers were unable to post news because of the long time the notify_contributors method would take. This should fix it.
