### PR TITLE
create unsuccessful project notification for credit_card contributions

### DIFF
--- a/app/observers/contribution_observer.rb
+++ b/app/observers/contribution_observer.rb
@@ -31,12 +31,7 @@ class ContributionObserver < ActiveRecord::Observer
   def from_confirmed_to_requested_refund(contribution)
     contribution.notify_to_backoffice :refund_request, {from_email: contribution.user.email, from_name: contribution.user.name}
     contribution.direct_refund if contribution.can_do_refund?
-    template_name = if contribution.slip_payment?
-                      :requested_refund_slip
-                    elsif contribution.is_credit_card? || contribution.is_paypal?
-                      :requested_refund
-                    end
-    contribution.notify_to_contributor(template_name) if template_name
+    contribution.notify_to_contributor(:requested_refund_slip) if contribution.slip_payment?
   end
 
   def from_confirmed_to_canceled(contribution)

--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -93,6 +93,8 @@ class ProjectObserver < ActiveRecord::Observer
                           :contribution_project_successful
                         elsif (contribution.credits? || contribution.slip_payment?)
                           :contribution_project_unsuccessful
+                        elsif contribution.is_paypal? || contribution.is_credit_card?
+                          :contribution_project_unsuccessful_credit_card
                         else
                           :automatic_refund
                         end

--- a/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
+++ b/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
@@ -1,0 +1,28 @@
+- contribution = @notification.contribution
+
+|Olá, #{contribution.user.name}!
+br
+br
+| Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))}
+| que você apoiou não atingiu a meta estabelecida e não foi financiado no #{CatarseSettings[:company_name]}.
+br
+br
+| Em até 5 dias úteis faremos o reembolso do valor do seu apoio, que <strong>virá como crédito na próxima ou 
+| subsequente fatura do seu cartão</strong>. Assim que o reembolso for feito você receberá um e-mail de confirmação da operação.
+br
+br
+| Segundo as novas regras do Catarse, <strong>os apoios feitos via cartão de crédito ou Paypal para projetos 
+| não financiados serão automaticamente reembolsados</strong>, logo, eles não geram mais créditos dentro do 
+| #{CatarseSettings[:company_name]} (que anteriormente podiam ser utilizados para colaborar com outros projetos).
+br
+br
+| Estas novas regras passaram a vigorar para projetos que encerraram a captação a partir de 11/09/2014.
+br
+br
+| Se ficou com alguma dúvida, entre em contato conosco respondendo a esta mensagem ou através do e-mail #{mail_to CatarseSettings[:email_contact]} 
+| e nos informe a chave de identificação do seu apoio, que é: #{contribution.payment_id || contribution.id}
+br
+br
+|Um abraço,
+br
+| #{CatarseSettings[:company_name]}

--- a/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card_subject.text.slim
+++ b/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card_subject.text.slim
@@ -1,0 +1,1 @@
+| Reembolso: apoio para o projeto não-financiado #{@notification.contribution.project.name}

--- a/spec/observers/contribution_observer_spec.rb
+++ b/spec/observers/contribution_observer_spec.rb
@@ -130,8 +130,8 @@ describe ContributionObserver do
         expect(ContributionNotification.where(template_name: 'refund_request', user_id: admin.id, from_email: contribution.user.email, from_name: contribution.user.name).count).to eq 1
       end
 
-      it "should notify contributor about the refund request" do
-        expect(ContributionNotification.where(template_name: 'requested_refund', user_id: contribution.user.id).count).to eq 1
+      it "should not notify contributor about the refund request" do
+        expect(ContributionNotification.where(template_name: 'requested_refund', user_id: contribution.user.id).count).to eq 0
       end
     end
 


### PR DESCRIPTION
drop the requested_refund notification for credit_card an paypal and
send a new notification when projects fails only for credit_card and
paypal contributions
