### PR TITLE
update pagarme to change IPN url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'mixpanel-ruby'
 gem 'catarse_paypal_express', '2.2.3'
 gem 'catarse_moip', '~> 2.3.6'
 gem 'catarse_credits', '0.0.6'
-gem 'catarse_pagarme', '1.0.1'
+gem 'catarse_pagarme', '1.1.0'
 gem 'catarse_contribution_validator', github: 'catarse/catarse_contribution_validator'
 # gem 'catarse_wepay', '~> 0.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       mailchimp-api (~> 2.0.4)
       rails (>= 4.0.3)
       rails-observers
-    catarse_pagarme (1.0.1)
+    catarse_pagarme (1.1.0)
       pagarme (~> 1.9.5)
       rails (~> 4.0)
     catarse_paypal_express (2.2.3)
@@ -499,7 +499,7 @@ DEPENDENCIES
   catarse_credits (= 0.0.6)
   catarse_moip (~> 2.3.6)
   catarse_monkeymail (>= 0.1.6)
-  catarse_pagarme (= 1.0.1)
+  catarse_pagarme (= 1.1.0)
   catarse_paypal_express (= 2.2.3)
   catarse_settings_db (>= 0.1.0)
   chartkick


### PR DESCRIPTION
Upadate to catarse_pagarme 1.1.0 to avoid error on IPNs from subscriptions.
