### PR TITLE
[#15003204] Removed Engaged with catarse event from 'select reward'. Is ...

### DIFF
--- a/app/assets/javascripts/app/mix_panel.js
+++ b/app/assets/javascripts/app/mix_panel.js
@@ -18,16 +18,23 @@ App.addChild('MixPanel', {
     this.trackPageVisit('projects', 'show', 'Visited project page');
     this.trackPageVisit('explore', 'index', 'Explored projects');
     this.trackPageLoad('contributions', 'edit', 'Selected reward');
-    this.trackPageLoad('contributions', 'edit', 'Engaged with Catarse');
     this.trackTwitterShare();
     this.trackFacebookShare();
     this.trackReminderClick();
+    this.trackFollowCategory();
     try {
       this.trackOnFacebookLike();
       this.trackOnFacebookComment();
     } catch(e) {
       console.log(e);
     }
+  },
+
+  trackFollowCategory: function(){
+    this.$('.category-follow .follow-btn').on('click', function(event){
+      self.track('Engaged with Catarse', { ref: $(event.currentTarget).data('title'), action: 'click follow category' });
+      return true;
+    });
   },
 
   trackReminderClick: function(){


### PR DESCRIPTION
...too confusing to have the same page load trigger two events. Added event to track the follow category button.
