### PR TITLE
use contributions.confirmed_at instead created_at

### DIFF
--- a/app/controllers/projects/metrics_controller.rb
+++ b/app/controllers/projects/metrics_controller.rb
@@ -17,24 +17,23 @@ class Projects::MetricsController < ApplicationController
   protected
 
   def total_by_address_state
-    @metrics[:address_state] = collection.with_state('confirmed').
-      joins(:user).group("upper(users.address_state)").count
+    @metrics[:address_state] = collection.joins(:user).group("upper(users.address_state)").count
   end
 
   def total_confirmed_by_day
-    @metrics[:confirmed] = collection.with_state('confirmed').
-      group("contributions.created_at::date AT TIME ZONE '#{Time.zone.tzinfo.name}'").
-      count
+    @metrics[:confirmed] = collection.group("
+      contributions.confirmed_at::date AT TIME ZONE '#{Time.zone.tzinfo.name}'
+    ").count
   end
 
   def confirmed_amount_by_day
-    @metrics[:confirmed_amount_by_day] = collection.with_state('confirmed').
-      group("contributions.created_at::date AT TIME ZONE '#{Time.zone.tzinfo.name}'").
-      sum(:value)
+    @metrics[:confirmed_amount_by_day] = collection.group("
+      contributions.confirmed_at::date AT TIME ZONE '#{Time.zone.tzinfo.name}'"
+    ).sum(:value)
   end
 
   def collection
-    @contributions ||= parent.contributions.not_created_today
+    @contributions ||= parent.contributions.with_state('confirmed')
   end
 
   def parent


### PR DESCRIPTION
We use confirmed_at on contributions reports, because that the sum with report don't has same result
