### PR TITLE
Project notification unsubscribe refactor

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,6 @@ class UsersController < ApplicationController
     show!{
       fb_admins_add(@user.facebook_id) if @user.facebook_id
       @title = "#{@user.display_name}"
-      @subscribed_to_posts = @user.posts_subscription
       @unsubscribes = @user.project_unsubscribes
       @credit_cards = @user.credit_cards
       build_bank_account
@@ -52,7 +51,6 @@ class UsersController < ApplicationController
   def edit
     authorize resource
     @unsubscribes = @user.project_unsubscribes
-    @subscribed_to_posts = @user.posts_subscription
     resource.links.build
     build_bank_account
   end
@@ -105,12 +103,6 @@ class UsersController < ApplicationController
   end
 
   def drop_and_create_subscriptions
-    #unsubscribe to all projects
-    if params[:subscribed].nil?
-      @user.unsubscribes.create!(project_id: nil)
-    else
-      @user.unsubscribes.drop_all_for_project(nil)
-    end
     if params[:unsubscribes]
       params[:unsubscribes].each do |subscription|
         project_id = subscription[0].to_i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,8 @@ class User < ActiveRecord::Base
     :image_url, :uploaded_image, :bio, :newsletter, :full_name, :address_street, :address_number,
     :address_complement, :address_neighbourhood, :address_city, :address_state, :address_zip_code, :phone_number,
     :cpf, :state_inscription, :locale, :twitter, :facebook_link, :other_link, :moip_login, :deactivated_at, :reactivate_token,
-    :bank_account_attributes, :country_id, :zero_credits, :links_attributes, :about, :about_html, :cover_image, :category_followers_attributes, :category_follower_ids
+    :bank_account_attributes, :country_id, :zero_credits, :links_attributes, :about, :about_html, :cover_image, :category_followers_attributes, :category_follower_ids,
+    :subscribed_to_project_posts
 
   mount_uploader :uploaded_image, UserUploader
   mount_uploader :cover_image, CoverUploader
@@ -72,10 +73,7 @@ class User < ActiveRecord::Base
   }
 
   scope :subscribed_to_posts, -> {
-     where("id NOT IN (
-       SELECT user_id
-       FROM unsubscribes
-       WHERE project_id IS NULL)")
+     where("subscribed_to_project_posts")
    }
 
   scope :subscribed_to_project, ->(project_id) {
@@ -209,10 +207,6 @@ class User < ActiveRecord::Base
   def to_param
     return "#{self.id}" unless self.display_name
     "#{self.id}-#{self.display_name.parameterize}"
-  end
-
-  def posts_subscription
-    unsubscribes.posts_unsubscribe(nil)
   end
 
   def project_unsubscribes

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -28,7 +28,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    u_attrs = [:current_password, :password, bank_account_attributes: [:bank_id, :name, :agency, :account, :owner_name, :owner_document, :account_digit, :agency_digit] ]
+    u_attrs = [:current_password, :password, :subscribed_to_project_post, bank_account_attributes: [:bank_id, :name, :agency, :account, :owner_name, :owner_document, :account_digit, :agency_digit] ]
     u_attrs << { category_follower_ids: [] }
     u_attrs << record.attribute_names.map(&:to_sym)
     u_attrs << { links_attributes: [:id, :_destroy, :link] }

--- a/app/views/catarse_bootstrap/users/_dashboard_notifications.html.slim
+++ b/app/views/catarse_bootstrap/users/_dashboard_notifications.html.slim
@@ -27,8 +27,9 @@
                           li
                             .w-checkbox.w-clearfix
                               = hidden_field_tag "unsubscribes[#{u.object.project.id}]", '' 
-                              = check_box_tag "user_unsubscribes_#{u.object.project_id}", "1", u.object.created_at.nil?, class: 'w-checkbox-input', name: "unsubscribes[#{u.object.project.id}]"
-                              label.w-form-label.fontsize-small= u.object.project.name
+                              - unsubscribe_id = "user_unsubscribes_#{u.object.project_id}"
+                              = check_box_tag unsubscribe_id, "1", u.object.created_at.nil?, class: 'w-checkbox-input', name: "unsubscribes[#{u.object.project.id}]"
+                              label.w-form-label.fontsize-small[for=unsubscribe_id] = u.object.project.name
               .w-row.u-marginbottom-20
                 .w-col.w-col-4
                   .fontweight-semibold.fontsize-small.u-marginbottom-10 Categorias que você segue:
@@ -50,7 +51,7 @@
         .w-container
           .w-row
             .w-col.w-col-4.w-col-push-4
-              = f.submit 'Salvar',  class:'btn btn-large'
+              = f.submit 'Salvar',  id: 'save', class:'btn btn-large'
  
 
 

--- a/app/views/catarse_bootstrap/users/_dashboard_notifications.html.slim
+++ b/app/views/catarse_bootstrap/users/_dashboard_notifications.html.slim
@@ -16,9 +16,8 @@
                   .fontweight-semibold.fontsize-small.u-marginbottom-10 Projetos que você apoiou:
                 .w-col.w-col-8
                   .w-checkbox.w-clearfix
-                    = f.simple_fields_for :unsubscribes, @subscribed_to_posts do |u|
-                      = check_box_tag :subscribed, "1", @user.subscribed_to_posts?, class: 'w-checkbox-input'
-                      label.w-form-label.fontsize-base.fontweight-semibold  Quero receber atualizações dos projetos
+                    = f.check_box :subscribed_to_project_posts, class: 'w-checkbox-input'
+                    label.w-form-label.fontsize-base.fontweight-semibold  Quero receber atualizações dos projetos
                     .u-marginbottom-20
                       a.alt-link#toggle-notifications href="#"  Gerenciar as notificações de #{@user.contributed_projects.count} projetos
                     - if @unsubscribes

--- a/db/migrate/20150317203333_add_subscribed_to_project_posts_to_users.rb
+++ b/db/migrate/20150317203333_add_subscribed_to_project_posts_to_users.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToProjectPostsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :subscribed_to_project_posts, :boolean, default: true
+  end
+end

--- a/db/migrate/20150317203743_change_project_id_to_not_null_in_unsubscribes.rb
+++ b/db/migrate/20150317203743_change_project_id_to_not_null_in_unsubscribes.rb
@@ -1,0 +1,10 @@
+class ChangeProjectIdToNotNullInUnsubscribes < ActiveRecord::Migration
+  def change
+    execute "
+    UPDATE users SET subscribed_to_project_posts = false
+    WHERE EXISTS (SELECT true FROM unsubscribes u WHERE u.user_id = users.id AND u.project_id IS NULL);
+    DELETE FROM unsubscribes WHERE project_id IS NULL;
+    "
+    change_column_null :unsubscribes, :project_id, false
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe UsersController, type: :controller do
       it("should update the user and nested models") do
         user.reload
         expect(user.twitter).to eq('test')
-        expect(user.unsubscribes.size).to eq(1)
         expect(user.category_followers.size).to eq(1)
       end
       it{ is_expected.to redirect_to edit_user_path(user) }

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -17,5 +17,37 @@ RSpec.describe "Users", type: :feature do
     it { expect(current_path).to eq(project_by_slug_path(permalink: @project.permalink)) }
   end
 
+  describe "Unsubscribing from all project notifications" do
+    let(:set_initial_unsubscribe_state){ nil }
+
+    def toggle_subscription state
+      # Had to use JS here, capybara was triggering some bizarre errors
+      expect(page.evaluate_script('$("#subscribed").is(":checked")')).to eq !state
+      page.execute_script "$('#subscribed').prop('checked', #{state})"
+      page.execute_script "$('#save').click()"
+      sleep FeatureHelpers::TIME_TO_SLEEP
+      expect(page.evaluate_script('$("#subscribed").is(":checked")')).to eq state
+    end
+
+    before do
+      login
+      set_initial_unsubscribe_state
+      visit edit_user_path current_user, anchor: 'notifications'
+      sleep FeatureHelpers::TIME_TO_SLEEP
+    end
+
+    context "when user is unsubscribed" do
+      let(:set_initial_unsubscribe_state){ current_user.unsubscribes.create!(project_id: nil) }
+      it "should check the checkbox and add a record to unsubscribes with project_id null" do
+        toggle_subscription true
+      end
+    end
+
+    context "when user is subscribed" do
+      it "should uncheck the checkbox and add a record to unsubscribes with project_id null" do
+        toggle_subscription false
+      end
+    end
+  end
 end
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe "Users", type: :feature do
 
     def toggle_subscription state
       # Had to use JS here, capybara was triggering some bizarre errors
-      expect(page.evaluate_script('$("#subscribed").is(":checked")')).to eq !state
-      page.execute_script "$('#subscribed').prop('checked', #{state})"
+      expect(page.evaluate_script('$("#user_subscribed_to_project_posts").is(":checked")')).to eq !state
+      page.execute_script "$('#user_subscribed_to_project_posts').prop('checked', #{state})"
       page.execute_script "$('#save').click()"
       sleep FeatureHelpers::TIME_TO_SLEEP
-      expect(page.evaluate_script('$("#subscribed").is(":checked")')).to eq state
+      expect(page.evaluate_script('$("#user_subscribed_to_project_posts").is(":checked")')).to eq state
     end
 
     before do
@@ -37,7 +37,7 @@ RSpec.describe "Users", type: :feature do
     end
 
     context "when user is unsubscribed" do
-      let(:set_initial_unsubscribe_state){ current_user.unsubscribes.create!(project_id: nil) }
+      let(:set_initial_unsubscribe_state){ current_user.update_attributes subscribed_to_project_posts: false }
       it "should check the checkbox and add a record to unsubscribes with project_id null" do
         toggle_subscription true
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -373,17 +373,6 @@ RSpec.describe User, type: :model do
     it{ is_expected.to eq([unfinished_project])}
   end
 
-  describe "#posts_subscription" do
-    subject{user.posts_subscription}
-    context "when user is subscribed to all projects" do
-      it{ is_expected.to be_new_record }
-    end
-    context "when user is unsubscribed from all projects" do
-      before { @u = create(:unsubscribe, project_id: nil, user_id: user.id )}
-      it{ is_expected.to eq(@u)}
-    end
-  end
-
   describe "#project_unsubscribes" do
     subject{user.project_unsubscribes}
     before do


### PR DESCRIPTION
 * Moves subscription of project posts to a boolean attribute in the user model
 * Refactor scopes accordingly
 * Removes unneeded cruft