### PR TITLE
Fixes dashboard progress bar

### DIFF
--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -47,13 +47,6 @@ class ProjectDecorator < Draper::Decorator
     end
   end
 
-  # Method for width of progress bars only
-  def display_progress
-    return 100 if source.successful? || source.progress > 100
-    return 8 if source.progress > 0 and source.progress < 8
-    source.progress
-  end
-
   def display_image(version = 'project_thumb' )
     use_uploaded_image(version) || use_video_tumbnail(version)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ActiveRecord::Base
 
   mount_uploader :uploaded_image, ProjectUploader
 
-  delegate  :display_online_date, :display_status, :progress, :display_progress,
+  delegate  :display_online_date, :display_status, :progress, 
             :display_image, :display_expires_at, :remaining_text, :time_to_go,
             :display_pledged, :display_goal, :remaining_days, :progress_bar,
             :status_flag, :state_warning_template, :display_card_class, :display_errors, to: :decorator

--- a/app/views/catarse_bootstrap/projects/dashboard_home_templates/_project_numbers.html.slim
+++ b/app/views/catarse_bootstrap/projects/dashboard_home_templates/_project_numbers.html.slim
@@ -4,7 +4,7 @@
   .w-row
     .w-col.w-col-3.w-col-small-3.w-col-tiny-6
       .fontweight-semibold.fontsize-large.lineheight-tight
-        = "#{@project.display_progress} %"
+        = "#{@project.progress} %"
       .fontcolor-secondary.lineheight-tighter.fontsize-small.u-marginbottom-10
         = t('.financed')
     .w-col.w-col-3.w-col-small-3.w-col-tiny-6

--- a/spec/decorators/project_decorator_spec.rb
+++ b/spec/decorators/project_decorator_spec.rb
@@ -125,26 +125,6 @@ RSpec.describe ProjectDecorator do
     end
   end
 
-  describe "#display_progress" do
-    subject{ project.display_progress }
-    context "when progress is 0" do
-      before{ allow(project).to receive(:progress).and_return(0) }
-      it{ is_expected.to eq(0) }
-    end
-    context "when progress is between 0 and 8" do
-      before{ allow(project).to receive(:progress).and_return(7) }
-      it{ is_expected.to eq(8) }
-    end
-    context "when progress is between 8 and 100" do
-      before{ allow(project).to receive(:progress).and_return(70) }
-      it{ is_expected.to eq(70) }
-    end
-    context "when progress is above 100" do
-      before{ allow(project).to receive(:progress).and_return(101) }
-      it{ is_expected.to eq(100) }
-    end
-  end
-
   describe "#display_card_class" do
     subject{ project.display_card_class }
     let(:default_card){ "card u-radius zindex-10" }


### PR DESCRIPTION
Stops using display_progress method. It was used to display the progress bar but now it was mistakenly used to show progress in the dashboard and nothing else. So I just removed the method