### PR TITLE
Prevents wrong iframe size calculation

### DIFF
--- a/app/assets/javascripts/app/user/show.js
+++ b/app/assets/javascripts/app/user/show.js
@@ -4,7 +4,7 @@ App.addChild('UserShow', _.extend({
   activate: function(){
     var that = this;
 
-    this.$container = $(".w-col-8");
+    this.$container = $("#about-content .w-col-8").first();
 
     this.route('contributed');
     this.route('created');

--- a/app/assets/javascripts/lib/ui_helper.js
+++ b/app/assets/javascripts/lib/ui_helper.js
@@ -12,8 +12,11 @@ Skull.UI_helper = {
           .removeAttr('width');
       }
     });
-    this.updateIframeSize();
     this.windowResize();
+    //Prevents wrong container width calculation
+    setTimeout(function(){
+      this.updateIframeSize();  
+    },0);
   },
 
   windowResize: function() {

--- a/app/views/catarse_bootstrap/users/_user_about.html.slim
+++ b/app/views/catarse_bootstrap/users/_user_about.html.slim
@@ -1,4 +1,4 @@
-.w-container
+#about-content.w-container
   .w-row
     .w-col.w-col-8
       .fontsize-base


### PR DESCRIPTION
Needed to add a setTimeout to put the first iframe size calculation to the end of the execution queue, preventing wrong container calculation.

Also adds better JS targeting on the user view. 