### PR TITLE
Sends to users the gateway id not our internal payment id

### DIFF
--- a/app/views/catarse_bootstrap/user_notifier/mailer/_contribution_data.html.slim
+++ b/app/views/catarse_bootstrap/user_notifier/mailer/_contribution_data.html.slim
@@ -22,7 +22,7 @@ p
     br/
     | Estimativa de entrega: #{contribution.reward.display_deliver_estimate}
     br/
-  | ID do apoio: #{detail.payment_id}
+  | ID do apoio: #{detail.gateway_id}
   br/
   / We need the || for some old projects do not have the account info
   - owner = contribution.project.account || contribution.project.user


### PR DESCRIPTION
This bug was originated during the renaming of the fields of the last payments refactor