### PR TITLE
Removes user locale from set_locale and avoid setting locale to anything not listed in AVAILABLE_LOCALES

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ class ApplicationController < ActionController::Base
   end
 
   def is_locale_available?
-    params[:locale].blank? || AVAILABLE_LOCALES.include?(params[:locale])
+    params[:locale].blank? || AVAILABLE_LOCALES.include?(params[:locale].to_s)
   end
 
   def after_sign_in_path_for(resource_or_scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 class ApplicationController < ActionController::Base
+  AVAILABLE_LOCALES = ['pt']
+
   include Concerns::ExceptionHandler
   include Concerns::MenuHandler
   include Concerns::SocialHelpersHandler
@@ -55,13 +57,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    if params[:locale]
-      I18n.locale = params[:locale]
-      current_user.try(:change_locale, params[:locale])
-    elsif request.method == "GET"
-      new_locale = current_user.try(:locale) || I18n.default_locale
-      redirect_to url_for(params.merge(locale: new_locale, only_path: true))
-    end
+    return redirect_to url_for(locale: I18n.default_locale, only_path: true) unless is_locale_available?
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def is_locale_available?
+    params[:locale].blank? || AVAILABLE_LOCALES.include?(params[:locale])
   end
 
   def after_sign_in_path_for(resource_or_scope)


### PR DESCRIPTION
This will avoid several bugs existing in our english version.
Also avoids the problem of having to redirect the user when he lands in catarse (the one responsible for redirecting to /projects in the home page)