### PR TITLE
Adds presence validations back to project_account model to match project_accounts not null attributes

### DIFF
--- a/app/models/project_account.rb
+++ b/app/models/project_account.rb
@@ -2,6 +2,8 @@ class ProjectAccount < ActiveRecord::Base
   belongs_to :project
   belongs_to :bank
 
+  validates_presence_of :email, :address_street, :address_number, :address_city, :address_state, :address_zip_code, :phone_number, :bank, :agency, :account, :account_digit, :owner_name, :owner_document, :account_type
+
   def entity_type
     if owner_document
       owner_document.length > 14 ? 'Pessoa Jurídica' : 'Pessoa Física'


### PR DESCRIPTION
Using this I can send projects to analysis wihout having to fill project_account. And I can still fill project_account even in finished projects that do not have this data.