### PR TITLE
Fix delete pending payments

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -14,7 +14,7 @@ class Payment < ActiveRecord::Base
     self.value ||= self.contribution.try(:value)
   end
 
-  scope :can_delete, ->{ with_state('pending').where("current_timestamp - payments.created_at > '1 week'::interval") }
+  scope :can_delete, ->{ where('payments.can_delete') }
 
   def generate_key
     self.key ||= SecureRandom.uuid

--- a/db/migrate/20150519154030_drop_can_cancel_function.rb
+++ b/db/migrate/20150519154030_drop_can_cancel_function.rb
@@ -1,0 +1,33 @@
+class DropCanCancelFunction < ActiveRecord::Migration
+  def up
+    execute "DROP FUNCTION can_cancel(contributions);"
+  end
+
+  def down
+    execute <<-SQL
+    CREATE OR REPLACE FUNCTION public.can_cancel(contributions)
+     RETURNS boolean
+     LANGUAGE sql
+    AS $function$
+            select
+              $1.state = 'waiting_confirmation' and
+              (
+                ((
+                  select count(1) as total_of_days
+                  from generate_series($1.created_at::date, (current_timestamp AT TIME ZONE coalesce((SELECT value FROM settings WHERE name = 'timezone'), 'America/Sao_Paulo'))::date, '1 day') day
+                  WHERE extract(dow from day) not in (0,1)
+                )  > 4)
+                OR
+                (
+                  lower($1.payment_choice) = lower('DebitoBancario')
+                  AND
+                    (
+                      select count(1) as total_of_days
+                      from generate_series($1.created_at::date, (current_timestamp AT TIME ZONE coalesce((SELECT value FROM settings WHERE name = 'timezone'), 'America/Sao_Paulo'))::date, '1 day') day
+                      WHERE extract(dow from day) not in (0,1)
+                    )  > 1)
+              )
+          $function$
+    SQL
+  end
+end

--- a/db/migrate/20150519154711_create_can_delete_function.rb
+++ b/db/migrate/20150519154711_create_can_delete_function.rb
@@ -1,0 +1,23 @@
+class CreateCanDeleteFunction < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+    CREATE OR REPLACE FUNCTION public.can_delete(payments)
+     RETURNS boolean
+     LANGUAGE sql
+    AS $function$
+            SELECT
+              $1.state = 'pending' 
+              AND
+              (
+                SELECT count(1) AS total_of_days
+                FROM generate_series($1.created_at::date, current_date, '1 day') day
+                WHERE extract(dow from day) not in (0,1)
+              )  >= 5
+          $function$
+    SQL
+  end
+
+  def down
+    execute "DROP FUNCTION can_delete(contributions);"
+  end
+end


### PR DESCRIPTION
Now the rule for deleteing pending payments is:
5 weekdays after creation.
It's a simpler version of our old rule.
I haven't touched the spec since our old spec covers this new rule and should pass with the new implementation.