### PR TITLE
move project online validation to payment instead contribution

### DIFF
--- a/app/models/concerns/contribution/custom_validators.rb
+++ b/app/models/concerns/contribution/custom_validators.rb
@@ -5,7 +5,6 @@ module Contribution::CustomValidators
     validate :reward_must_be_from_project
     validate :value_must_be_at_least_rewards_value
     validate :should_not_contribute_if_maximum_contributions_been_reached, on: :create
-    validate :project_should_be_online, on: :create
 
     def reward_must_be_from_project
       return unless reward
@@ -21,11 +20,5 @@ module Contribution::CustomValidators
       return unless reward && reward.maximum_contributions && reward.maximum_contributions > 0
       errors.add(:reward, I18n.t('contribution.should_not_contribute_if_maximum_contributions_been_reached')) if reward.sold_out?
     end
-
-    def project_should_be_online
-      return if project && project.online?
-      errors.add(:project, I18n.t('contribution.project_should_be_online'))
-    end
-
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -8,6 +8,12 @@ class Payment < ActiveRecord::Base
 
   validates_presence_of :state, :key, :gateway, :payment_method, :value, :installments
   validate :value_should_be_equal_or_greater_than_pledge
+  validate :project_should_be_online, on: :create
+
+  def project_should_be_online
+    return if project && project.online?
+    errors.add(:project, I18n.t('contribution.project_should_be_online'))
+  end
 
   before_validation do
     generate_key
@@ -21,7 +27,9 @@ class Payment < ActiveRecord::Base
   end
 
   def value_should_be_equal_or_greater_than_pledge
-    errors.add(:value, I18n.t("activerecord.errors.models.payment.attributes.value.invalid")) if self.contribution && self.value < self.contribution.value
+    if self.contribution && self.value < self.contribution.value
+      errors.add(:value, I18n.t("activerecord.errors.models.payment.attributes.value.invalid"))
+    end
   end
 
   def notification_template_for_failed_project

--- a/spec/models/concerns/contribution/custom_validators_spec.rb
+++ b/spec/models/concerns/contribution/custom_validators_spec.rb
@@ -34,30 +34,6 @@ RSpec.describe Contribution::CustomValidators, type: :model do
     end
   end
 
-  describe "#project_should_be_online" do
-    subject{ contribution }
-    context "when project is draft" do
-      let(:contribution){ build(:contribution, project: create(:project, state: 'draft')) }
-      it{ is_expected.not_to be_valid }
-    end
-    context "when project is waiting_funds" do
-      let(:contribution){ build(:contribution, project: create(:project, state: 'waiting_funds')) }
-      it{ is_expected.not_to be_valid }
-    end
-    context "when project is successful" do
-      let(:contribution){ build(:contribution, project: create(:project, state: 'successful')) }
-      it{ is_expected.not_to be_valid }
-    end
-    context "when project is online" do
-      let(:contribution){ build(:contribution, project: unfinished_project) }
-      it{ is_expected.to be_valid }
-    end
-    context "when project is failed" do
-      let(:contribution){ build(:contribution, project: create(:project, state: 'failed')) }
-      it{ is_expected.not_to be_valid }
-    end
-  end
-
   describe "#should_not_back_if_maximum_contributions_been_reached" do
     let(:reward){ create(:reward, maximum_contributions: 1) }
     let(:contribution){ build(:contribution, reward: reward, project: reward.project) }


### PR DESCRIPTION
this method avoid creation of payments when projects reached deadline