### PR TITLE
Revert "order projects randomly" [Fix #95424196]

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -134,6 +134,7 @@ class ProjectsController < ApplicationController
 
   def render_index_for_xhr_request
     @projects = apply_scopes(Project.visible.order_status)
+      .most_recent_first
       .includes(:project_total, :user, :category)
       .page(params[:page]).per(18)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,13 +77,13 @@ class Project < ActiveRecord::Base
   scope :not_expiring, -> { not_expired.where.not(expires_at: Time.current.. 2.weeks.from_now) }
   scope :recent, -> { where(online_date: 5.days.ago.. Time.current) }
   scope :ordered, -> { order(created_at: :desc)}
-  scope :order_status, ->{ reorder("
+  scope :order_status, ->{ order("
                                      CASE projects.state
                                      WHEN 'online' THEN 1
                                      WHEN 'waiting_funds' THEN 2
                                      WHEN 'successful' THEN 3
                                      WHEN 'failed' THEN 4
-                                     END ASC, random()")}
+                                     END ASC")}
   scope :most_recent_first, ->{ order("projects.online_date DESC, projects.created_at DESC") }
   scope :order_for_admin, -> {
     reorder("


### PR DESCRIPTION
This reverts commit 76ed7f8ba3efb4d36dd3bf585d2061ff5f4cb62b.