### PR TITLE
Fix error with role 'postgrest'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Cookbooks
 config/deploy/
 vendor/assets/components
 node_modules/
+.rbenv-gemsets

--- a/db/migrate/20150605214509_create_admin_role.rb
+++ b/db/migrate/20150605214509_create_admin_role.rb
@@ -1,8 +1,23 @@
 class CreateAdminRole < ActiveRecord::Migration
   def up
     execute <<-SQL
-    CREATE ROLE admin NOLOGIN;
-    CREATE ROLE postgrest NOLOGIN;
+    DO
+      $body$
+    BEGIN
+      IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles WHERE rolname = 'postgrest') THEN
+        CREATE ROLE postgrest NOLOGIN;
+      END IF;
+    END
+    $body$;
+
+    DO
+      $body$
+    BEGIN
+      IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles WHERE rolname = 'admin') THEN
+        CREATE ROLE admin NOLOGIN;
+      END IF;
+    END
+    $body$;
     -- This script assumes a role postgrest and a role anonymous already created
     GRANT usage ON SCHEMA postgrest TO admin;
     GRANT usage ON SCHEMA "1" TO admin;

--- a/db/migrate/20150605214509_create_admin_role.rb
+++ b/db/migrate/20150605214509_create_admin_role.rb
@@ -2,6 +2,7 @@ class CreateAdminRole < ActiveRecord::Migration
   def up
     execute <<-SQL
     CREATE ROLE admin NOLOGIN;
+    CREATE ROLE postgrest NOLOGIN;
     -- This script assumes a role postgrest and a role anonymous already created
     GRANT usage ON SCHEMA postgrest TO admin;
     GRANT usage ON SCHEMA "1" TO admin;

--- a/db/migrate/20150605215906_create_user_role.rb
+++ b/db/migrate/20150605215906_create_user_role.rb
@@ -1,7 +1,14 @@
 class CreateUserRole < ActiveRecord::Migration
   def up
     execute <<-SQL
-    CREATE ROLE web_user NOLOGIN;
+    DO
+      $body$
+    BEGIN
+      IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles WHERE rolname = 'web_user') THEN
+        CREATE ROLE web_user NOLOGIN;
+      END IF;
+    END
+    $body$;
     -- This script assumes a role postgrest and a role anonymous already created
     GRANT usage ON SCHEMA "1" TO web_user;
     GRANT select ON ALL TABLES IN SCHEMA "1" TO web_user;


### PR DESCRIPTION
### How to reproduce the error

With blank postgresql installation or only postgres and catarse user.

`psql -U catarse -d catarse_development -W`

With 

```bash
psql (9.4.4)
Type "help" for help.

catarse_development=# \du
                             List of roles
 Role name |                   Attributes                   | Member of 
-----------+------------------------------------------------+-----------
 catarse   | Superuser, Create DB                           | {}
 postgres  | Superuser, Create role, Create DB, Replication | {}

```


Run `rake db:create db:migrate`

return this trace

```bash
== 20150605214509 CreateAdminRole: migrating ==================================
-- execute("    CREATE ROLE admin NOLOGIN;\n    -- This script assumes a role postgrest and a role anonymous already created\n    GRANT usage ON SCHEMA postgrest TO admin;\n    GRANT usage ON SCHEMA \"1\" TO adm
in;\n    GRANT select, insert ON postgrest.auth TO admin;\n    GRANT select ON ALL TABLES IN SCHEMA \"1\" TO admin;\n    GRANT admin TO postgrest;\n")
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::UndefinedObject: ERROR:  role "postgrest" does not exist
:     CREATE ROLE admin NOLOGIN;
    -- This script assumes a role postgrest and a role anonymous already created
    GRANT usage ON SCHEMA postgrest TO admin;
    GRANT usage ON SCHEMA "1" TO admin;
    GRANT select, insert ON postgrest.auth TO admin;
    GRANT select ON ALL TABLES IN SCHEMA "1" TO admin;
    GRANT admin TO postgrest;
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `async_exec'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `block in execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:378:in `block in log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activesupport-4.1.11/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:372:in `log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:127:in `execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:656:in `block in method_missing'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `block in say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:648:in `method_missing'
/home/paulopatto/Code/catarse/db/migrate/20150605214509_create_admin_role.rb:3:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:605:in `exec_migration'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:586:in `block (2 levels) in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:585:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:584:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:759:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:998:in `block in execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `block in ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/transactions.rb:208:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:997:in `execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:959:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `each'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:814:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:792:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/railties/databases.rake:34:in `block (2 levels) in <top (required)>'
ActiveRecord::StatementInvalid: PG::UndefinedObject: ERROR:  role "postgrest" does not exist
:     CREATE ROLE admin NOLOGIN;
    -- This script assumes a role postgrest and a role anonymous already created
    GRANT usage ON SCHEMA postgrest TO admin;
    GRANT usage ON SCHEMA "1" TO admin;
    GRANT select, insert ON postgrest.auth TO admin;
    GRANT select ON ALL TABLES IN SCHEMA "1" TO admin;
    GRANT admin TO postgrest;
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `async_exec'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `block in execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:378:in `block in log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activesupport-4.1.11/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:372:in `log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:127:in `execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:656:in `block in method_missing'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `block in say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:648:in `method_missing'
/home/paulopatto/Code/catarse/db/migrate/20150605214509_create_admin_role.rb:3:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:605:in `exec_migration'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:586:in `block (2 levels) in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:585:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:584:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:759:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:998:in `block in execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `block in ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/transactions.rb:208:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:997:in `execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:959:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `each'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:814:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:792:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/railties/databases.rake:34:in `block (2 levels) in <top (required)>'
PG::UndefinedObject: ERROR:  role "postgrest" does not exist
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `async_exec'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `block in execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:378:in `block in log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activesupport-4.1.11/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract_adapter.rb:372:in `log'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/postgresql/database_statements.rb:127:in `execute'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:656:in `block in method_missing'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `block in say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:628:in `say_with_time'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:648:in `method_missing'
/home/paulopatto/Code/catarse/db/migrate/20150605214509_create_admin_role.rb:3:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:605:in `exec_migration'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:586:in `block (2 levels) in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:585:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:584:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:759:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:998:in `block in execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `block in ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/transactions.rb:208:in `transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:1044:in `ddl_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:997:in `execute_migration_in_transaction'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:959:in `block in migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `each'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:955:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:814:in `up'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/migration.rb:792:in `migrate'
/home/paulopatto/.rbenv/versions/2.2.2/gemsets/catarse/gems/activerecord-4.1.11/lib/active_record/railties/databases.rake:34:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

My env: Ubuntu 14.04 (3.16.0-34-generic) with (PostgreSQL) 9.4.4