### PR TITLE
Adds data-stats to .project-dashboard-edit

### DIFF
--- a/app/views/catarse_bootstrap/projects/edit.html.slim
+++ b/app/views/catarse_bootstrap/projects/edit.html.slim
@@ -3,13 +3,7 @@
 - content_for :stylesheets do
   = stylesheet_link_tag 'redactor'
 = render 'shared/header'
-#dashboard-titles-root.w-section.dashboard-header.u-text-center data-stats="#{@project.try(:to_analytics_json)}"
-  .w-container
-    .w-row
-      .w-col.w-col-8.w-col-push-2.u-marginbottom-30
-        #dashboard-page-title.fontweight-semibold.fontsize-larger.lineheight-looser
-        #dashboard-page-subtitle.fontsize-base
-.project-dashboard-edit
+.project-dashboard-edit[data-stats="#{@project.try(:to_analytics_json)}"]
   = render partial: 'dashboard_nav', locals: {edit_page: true}
   section.min-height-70
     #current_anchor data-anchor="#{params[:anchor]}"


### PR DESCRIPTION
and removed unused html element (it seems that slim was removing the empty element in production) [fix #102539208]