### PR TITLE
Increase minimum postgresql version to 9.4

### DIFF
--- a/config/database.sample.yml
+++ b/config/database.sample.yml
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 9.1 or later are supported.
+# PostgreSQL. Versions 9.4 or later are supported.
 #
 # Install the pg driver:
 #   gem install pg


### PR DESCRIPTION
Stuff like json_build_object works starting from postgres version 9.4

Comment about postgresql version in sample database.yml
is misleading.