### PR TITLE
Fix shoulda-matchers deprecation

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Project, type: :model do
     it{ is_expected.to validate_numericality_of(:goal) }
     it{ is_expected.to allow_value(10).for(:goal) }
     it{ is_expected.not_to allow_value(8).for(:goal) }
-    it{ is_expected.to ensure_length_of(:headline).is_at_most(Project::HEADLINE_MAXLENGTH) }
+    it{ is_expected.to validate_length_of(:headline).is_at_most(Project::HEADLINE_MAXLENGTH) }
     it{ is_expected.to allow_value('http://vimeo.com/12111').for(:video_url) }
     it{ is_expected.to allow_value('vimeo.com/12111').for(:video_url) }
     it{ is_expected.to allow_value('https://vimeo.com/12111').for(:video_url) }


### PR DESCRIPTION
there's one intentionally untouched deprecation left in spec suite:

```
--------------------------------------------------------------------------------
CarrierWave::Test::Matchers::HaveDimensions implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from /spec/uploaders/user_uploader_spec.rb:19:in
`block (3 levels) in <top (required)>')
--------------------------------------------------------------------------------
```
[carrierwave issue](https://github.com/carrierwaveuploader/carrierwave/issues/1418)