### PR TITLE
PostgreSQL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The official repo is https://github.com/catarse/catarse
 To run this project you need to have:
 
 * Ruby 2.2.3
-* [PostgreSQL](http://www.postgresql.org/)
+* [PostgreSQL 9.4](http://www.postgresql.org/)
   * OSX - [Postgres.app](http://postgresapp.com/)
   * Linux - `$ sudo apt-get install postgresql`
   * Windows - [PostgreSQL for Windows](http://www.postgresql.org/download/windows/)


### PR DESCRIPTION
Catarse requires PostgreSQL v9.4 which includes improvements in window functions and filtering for aggregation.