### PR TITLE
Donation hotfixes

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -41,6 +41,7 @@ class Contribution < ActiveRecord::Base
       join contribution_details cd on cd.contribution_id = contributions.id
       ").where("
       cd.project_state = 'failed'
+      and contributions.donation_id is null
       and cd.state = 'paid'
       and lower(cd.gateway) = 'pagarme'
       and lower(cd.payment_method) = 'boletobancario'

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -112,7 +112,8 @@ class Payment < ActiveRecord::Base
     end
 
     event :pay do
-      transition [:pending, :pending_refund, :chargeback, :refunded] => :paid
+      transition [:pending, :pending_refund, :chargeback, :refunded] => :paid,
+        unless: ->(payment) { payment.is_donation? }
     end
 
     event :refuse do
@@ -126,6 +127,7 @@ class Payment < ActiveRecord::Base
     event :refund do
       transition [:pending_refund, :paid, :deleted] => :refunded
     end
+
 
     after_transition do |payment, transition|
       payment.notify_observers :"from_#{transition.from}_to_#{transition.to}"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -204,6 +204,11 @@ FactoryGirl.define do
     f.deliver_at 1.year.from_now
   end
 
+  factory :donation do |f|
+    f.amount 10
+    f.association :user
+  end
+
 
   factory :contribution do |f|
     f.association :project, factory: :project

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -180,10 +180,12 @@ RSpec.describe Contribution, type: :model do
     let(:project) { create(:project) }
     let(:refunded_contribution) { create(:refunded_contribution, project: project) }
     let(:paid_contribution) { create(:confirmed_contribution, project: project) }
+    let(:paid_with_donation_contribution) { create(:confirmed_contribution, project: project, donation: create(:donation)) }
 
     subject { Contribution.need_notify_about_pending_refund }
     before do
       paid_contribution.payments.first.update_attributes({payment_method: 'BoletoBancario'})
+      paid_with_donation_contribution.payments.first.update_attributes({payment_method: 'BoletoBancario'})
       refunded_contribution
       project.update_column(:state, 'failed')
     end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -63,6 +63,32 @@ RSpec.describe Payment, type: :model do
     end
   end
 
+  describe "#pay" do
+    let(:payment) {
+      contribution.payments.first
+    }
+
+    subject { payment.paid? }
+
+    context "when payment is donation" do
+      let(:contribution) { create(:refunded_contribution, donation: create(:donation)) }
+      before { payment.pay }
+
+      it "should not turn payment to paid" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when payment is not donated" do
+      let(:contribution) { create(:refunded_contribution) }
+      before { payment.pay }
+
+      it "should turn payment to paid" do
+        is_expected.to eq(true)
+      end
+    end
+  end
+
   describe "#project_should_be_online" do
     subject{ payment }
     context "when project is draft" do


### PR DESCRIPTION
- [x] Should not turn payment to paid when is a donation, this prevent to send notifications about pending refund.