### PR TITLE
Upgrade Nokogiri to fix some vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     multipart-post (2.0.0)
     netrc (0.11.0)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     oauth (0.4.7)
     oauth2 (1.0.0)


### PR DESCRIPTION
Name: nokogiri
Version: 1.6.7
Advisory: CVE-2015-5312
Criticality: High
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
Title: Nokogiri gem contains several vulnerabilities in libxml2
Solution: upgrade to >= 1.6.7.1

Name: nokogiri
Version: 1.6.7
Advisory: CVE-2015-7499
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/Dy7YiKb_pMM
Title: Nokogiri gem contains a heap-based buffer overflow vulnerability in libxml2
Solution: upgrade to >= 1.6.7.2