### PR TITLE
Upgrade devise to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    bcrypt (3.1.10)
+    bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -132,7 +132,7 @@ GEM
       sass-rails
       slim-rails
     debug_inspector (0.0.2)
-    devise (3.5.3)
+    devise (3.5.10)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -279,7 +279,7 @@ GEM
     mime-types (2.99)
     mini_magick (4.3.6)
     mini_portile2 (2.0.0)
-    minitest (5.8.3)
+    minitest (5.9.0)
     mixpanel-ruby (2.2.0)
     mixpanel_client (4.1.3)
       typhoeus
@@ -366,7 +366,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
-    rake (10.5.0)
+    rake (11.1.2)
     ranked-model (0.4.0)
       activerecord (>= 3.1.12)
     rb-fsevent (0.9.6)
@@ -506,7 +506,7 @@ GEM
       addressable
       htmlentities
       multi_json
-    warden (1.2.4)
+    warden (1.2.6)
       rack (>= 1.0)
     websocket (1.2.2)
     websocket-driver (0.6.3)


### PR DESCRIPTION
Name: devise
Version: 3.5.3
Advisory: CVE-2015-8314
Criticality: Unknown
URL: http://blog.plataformatec.com.br/2016/01/improve-remember-me-cookie-expiration-in-devise/
Title: Devise Gem for Ruby Unauthorized Access Using Remember Me Cookie
Solution: upgrade to >= 3.5.4