### PR TITLE
Include link to description ebook on Description Dashboard

### DIFF
--- a/app/views/catarse_bootstrap/projects/_dashboard_description.html.slim
+++ b/app/views/catarse_bootstrap/projects/_dashboard_description.html.slim
@@ -3,6 +3,12 @@
     .w-container
       .w-row
         .w-col.w-col-10.w-col-push-1
+          .u-marginbottom-60.u-text-center
+            .w-inline-block.card.fontsize-small.u-radius
+              span.fa.fa-lightbulb-o
+              | Saiba como
+              a.alt-link href="https://catarse.attach.io/BJmQVOiR" target="_blank"  criar uma descrição cativante!
+
           .w-form
               = @project.display_errors(:description)
               =  hidden_field_tag 'project_id', @project.id


### PR DESCRIPTION
@vicnicius 

isso aqui é um teste que eu estou fazendo para medir tráfego para ebooks vindo direto do dashboard de projetos. quero saber se a gente consegue distribuir melhor esses conteúdos em um momento mais "sensível", ali direto no dashboard.

não sei se fiz o slim certo (useu o HTML2slim).. vc dá uma olhada? acho q está ok...

se funcionar pra mim já está bom rs (mesmo que o código não esteja 100%).. ou seja, mesmo que desse pra ser melhor e mais limpo, podemos limpar depois...

é só um teste mesmo e, caso eu veja ali que a coisa funcionou certinho, depois a gente pode "limpar" esse código ae e fazer ele direitinho

