### PR TITLE
Drop fb:admin 

### DIFF
--- a/app/controllers/concerns/social_helpers_handler.rb
+++ b/app/controllers/concerns/social_helpers_handler.rb
@@ -5,23 +5,7 @@ module Concerns
     # We use this method only to make stubing easier
     # and remove FB templates from acceptance tests
     included do
-      helper_method :fb_admins, :render_facebook_sdk, :render_facebook_like, :render_twitter, :render_twitter_mobile, :render_facebook_share, :render_facebook_share_mobile
-
-      before_filter do
-        @fb_admins = [100000428222603, 547955110]
-      end
-    end
-
-    def fb_admins
-      @fb_admins
-    end
-
-    def fb_admins_add(ids)
-      if ids.kind_of?(Array)
-        ids.each {|id| @fb_admins << id.to_i}
-      else
-        @fb_admins << ids.to_i
-      end
+      helper_method :render_facebook_sdk, :render_facebook_like, :render_twitter, :render_twitter_mobile, :render_facebook_share, :render_facebook_share_mobile
     end
 
     def render_facebook_sdk

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -145,7 +145,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    fb_admins_add(resource.user.facebook_id) if resource.user.facebook_id
     @post ||= resource.posts.where(id: params[:project_post_id].to_i).first if params[:project_post_id].present?
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,6 @@ class UsersController < ApplicationController
   def show
     authorize resource
     show!{
-      fb_admins_add(@user.facebook_id) if @user.facebook_id
       @title = "#{@user.display_name}"
       #@unsubscribes = @user.project_unsubscribes
       #@credit_cards = @user.credit_cards

--- a/app/views/catarse_bootstrap/projects/show.html.slim
+++ b/app/views/catarse_bootstrap/projects/show.html.slim
@@ -24,7 +24,6 @@
   meta property="og:image:width" content='666'
   meta property="og:image:height" content='488'
   meta property="fb:app_id" content=CatarseSettings[:fb_app_id]
-  meta property="fb:admins" content="#{fb_admins.join(',')}"
 
 - content_for :tracker_snippet_html do
   == @project.tracker_snippet_html

--- a/app/views/catarse_bootstrap/users/show.html.slim
+++ b/app/views/catarse_bootstrap/users/show.html.slim
@@ -6,7 +6,6 @@
   meta property="og:type" content='cause'
   meta[property="og:image" content=resource.uploaded_image.thumb_facebook.url]
   meta property="og:site_name" content=CatarseSettings[:company_name]
-  meta property="fb:admins" content="#{fb_admins.join(',')}"
 
 #application data-userid=resource.id data-hassubdomain=(resource.permalink == request.subdomain).to_s
 

--- a/spec/controllers/concerns/social_helpers_handler_spec.rb
+++ b/spec/controllers/concerns/social_helpers_handler_spec.rb
@@ -9,18 +9,6 @@ RSpec.describe Concerns::SocialHelpersHandler, type: :controller do
     @controller = ApplicationController.new
   end
 
-  describe '#fb_admins_add' do
-    before { @controller.instance_variable_set(:@fb_admins, []) }
-
-    context 'when is not an array' do
-      it { expect(@controller.fb_admins_add(1)).to eq [1] }
-    end
-
-    context 'when is an array' do
-      it { expect(@controller.fb_admins_add([1, 2])).to eq [1, 2] }
-    end
-  end
-
   describe '#render_facebook_sdk' do
     it { expect(@controller.render_facebook_sdk).to render_template(partial: 'layouts/_facebook_sdk') }
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -272,7 +272,6 @@ RSpec.describe UsersController, type: :controller do
 
     context "when user is active" do
       it{ is_expected.to be_successful }
-      it{ expect(assigns(:fb_admins)).to include(user.facebook_id.to_i) }
     end
 
     it "should set referral session" do


### PR DESCRIPTION
since we are using fb:app_id we don't need to use fb:admins (don't work with fb:app_id and scoped user ids)