### PR TITLE
fix flex expired projects [#145368025]

### DIFF
--- a/app/models/flexible_project.rb
+++ b/app/models/flexible_project.rb
@@ -37,4 +37,8 @@ class FlexibleProject < Project
     self.online_at + 365.days
   end
 
+  def expired?
+    pluck_from_database("is_expired")
+  end
+
 end


### PR DESCRIPTION
Flex projects past 365 days still won't have a expires_at set, se we check directly from db.