### PR TITLE
fix slip notification

### DIFF
--- a/app/observers/payment_observer.rb
+++ b/app/observers/payment_observer.rb
@@ -3,9 +3,9 @@
 class PaymentObserver < ActiveRecord::Observer
   observe :payment
 
-  def after_create(payment)
+  def after_save(payment)
     contribution = payment.contribution
-    contribution.notify_to_contributor(:payment_slip) if payment.slip_payment?
+    contribution.notify_to_contributor(:payment_slip) if payment.slip_payment? && payment.gateway_data
   end
 
   def from_pending_to_paid(payment)

--- a/spec/observers/payment_observer_spec.rb
+++ b/spec/observers/payment_observer_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe PaymentObserver do
 
   subject { payment }
 
-  describe 'after_create' do
+  describe 'after_save' do
     context 'when slip_payment is true' do
-      let(:payment) { create(:payment, payment_method: 'BoletoBancario', state: 'paid') }
+      let(:payment) { create(:payment, payment_method: 'BoletoBancario', state: 'paid', gateway_data: {}) }
       it('should notify the contribution') do
         expect(ContributionNotification.where(template_name: 'payment_slip', user: contribution.user, contribution: contribution).count).to eq 1
       end


### PR DESCRIPTION
Payments on create do not have gateway_data yet, resulting in a undefined method [] error.