### PR TITLE
should always finish projects [#147461577]

### DIFF
--- a/app/models/concerns/project/all_or_nothing_state_validator.rb
+++ b/app/models/concerns/project/all_or_nothing_state_validator.rb
@@ -9,7 +9,7 @@ module Project::AllOrNothingStateValidator
     with_options if: ->(x) { x.mode == 'aon' } do |wg|
       # Start validations when project state
       # is included on ON_ONLINE_TO_END_STATE
-      wg.with_options if: ->(x) { (Project::ON_ONLINE_TO_END_STATES.include? x.state) && (x.mode == 'aon') } do |wo|
+      wg.with_options if: ->(x) { (Project::VALIDATION_STATES.include? x.state) && (x.mode == 'aon') } do |wo|
         wo.validates_presence_of :goal, :online_days, :budget
         wo.validates_numericality_of :online_days, less_than_or_equal_to: 60, greater_than_or_equal_to: 1
       end

--- a/app/models/concerns/project/base_validator.rb
+++ b/app/models/concerns/project/base_validator.rb
@@ -6,7 +6,7 @@ module Project::BaseValidator
   extend ActiveSupport::Concern
 
   included do
-    ON_ONLINE_TO_END_STATES = %w[online successful waiting_funds failed].freeze
+    VALIDATION_STATES = %w[online].freeze
 
     # Validation for online? only state
     with_options if: :online? do |wo|
@@ -16,7 +16,7 @@ module Project::BaseValidator
 
     # Start validations when project state
     # is included on ON_ONLINE_TO_END_STATE
-    with_options if: ->(x) { ON_ONLINE_TO_END_STATES.include? x.state } do |wo|
+    with_options if: ->(x) { VALIDATION_STATES.include? x.state } do |wo|
       validates_numericality_of :online_days, less_than_or_equal_to: 365, greater_than_or_equal_to: 1, allow_nil: true, if: :is_flexible?
       wo.validates_presence_of :about_html, :headline, :goal
 

--- a/spec/models/concerns/project/all_or_nothing_state_validator_spec.rb
+++ b/spec/models/concerns/project/all_or_nothing_state_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Project::AllOrNothingStateValidator, type: :model do
       it { is_expected.to validate_numericality_of(:online_days).is_less_than_or_equal_to(60).is_greater_than_or_equal_to(1) }
     end
 
-    Project::ON_ONLINE_TO_END_STATES.each do |state|
+    Project::VALIDATION_STATES.each do |state|
       context "#{state} project validations" do
         let(:project_state) { state }
 

--- a/spec/models/concerns/project/base_validator_spec.rb
+++ b/spec/models/concerns/project/base_validator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Project::BaseValidator, type: :model do
   context 'when project is going to online to end state' do
     subject { project }
 
-    Project::ON_ONLINE_TO_END_STATES.each do |state|
+    Project::VALIDATION_STATES.each do |state|
       context "#{state} project validations" do
         let(:project_state) { state }
 


### PR DESCRIPTION
Allow legacy invalid projects to finish. All validations should occur before publication.