### PR TITLE
update chart call to match older version

### DIFF
--- a/app/assets/javascripts/api/application.js
+++ b/app/assets/javascripts/api/application.js
@@ -4,7 +4,7 @@
 //= require mithril-postgrest
 //= require moment/min/moment.min.js
 //= require lib/replace-diacritics
-//= require chart.js/dist/Chart.bundle.min.js
+//= require chart.js/Chart.min.js
 //= require i18n/translations
 //= require ../analytics
 //= require api/init


### PR DESCRIPTION
we were using an older version of 'chart.js'. this pr updates the require call to match it. 