### PR TITLE
fix force_www [#145718629]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,7 +144,7 @@ class ApplicationController < ActionController::Base
 
   def force_www
     if request.subdomain.blank? && Rails.env.production?
-      redirect_to url_for(params.merge(subdomain: 'www', locale: ''))
+      redirect_to request.original_url.gsub(/^https?\:\/\//, 'https://www.')
     end
   end
 


### PR DESCRIPTION
```url_for``` does not work for paths which have no defined route such as ```auth/facebook/```.