### PR TITLE
Email marketing lists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,9 +99,9 @@ class ApplicationController < ActionController::Base
 
   def subscribe_newsletter
     email = params['EMAIL']
+    list_id = (MailMarketingList.find_by list_id: params[:list_id]) || CatarseSettings[:sendgrid_newsletter_list_id]
 
     if email =~ EMAIL_REGEX
-      list_id = CatarseSettings[:sendgrid_newsletter_list_id]
       client = sendgrid_api.client
 
       rr = client.contactdb.recipients.post(request_body: [{ email: email }])

--- a/app/models/mail_marketing_list.rb
+++ b/app/models/mail_marketing_list.rb
@@ -1,0 +1,5 @@
+class MailMarketingList < ActiveRecord::Base
+  validates :provider, :label, :list_id, presence: true
+  validates :provider, :label, uniqueness: true
+  validates :provider, :list_id, uniqueness: true
+end

--- a/app/models/mail_marketing_list.rb
+++ b/app/models/mail_marketing_list.rb
@@ -1,5 +1,5 @@
 class MailMarketingList < ActiveRecord::Base
   validates :provider, :label, :list_id, presence: true
-  validates :provider, :label, uniqueness: true
-  validates :provider, :list_id, uniqueness: true
+  validates :provider,  uniqueness: {scope: :label }
+  validates :provider,  uniqueness: {scope: :list_id }
 end

--- a/app/models/mail_marketing_user.rb
+++ b/app/models/mail_marketing_user.rb
@@ -1,4 +1,8 @@
 class MailMarketingUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :mail_marketing_list
+
+  after_destroy do
+    SendgridSyncWorker.perform_async(user_id, mail_marketing_list_id)
+  end
 end

--- a/app/models/mail_marketing_user.rb
+++ b/app/models/mail_marketing_user.rb
@@ -1,0 +1,4 @@
+class MailMarketingUser < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :mail_marketing_list
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,7 @@ class User < ActiveRecord::Base
   has_many :categories, through: :category_followers
   has_many :links, class_name: 'UserLink', inverse_of: :user
   has_many :balance_transactions
+  has_many :mail_marketing_users
   has_and_belongs_to_many :recommended_projects, join_table: :recommendations, class_name: 'Project'
 
   begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
                   :image_url, :uploaded_image, :newsletter, :cpf, :state_inscription, :locale, :twitter, :facebook_link, :other_link, :moip_login, :deactivated_at, :reactivate_token,
                   :bank_account_attributes, :country_id, :zero_credits, :links_attributes, :about_html, :cover_image, :category_followers_attributes, :category_follower_ids,
                   :subscribed_to_project_posts, :subscribed_to_new_followers, :subscribed_to_friends_contributions, :whitelisted_at, :confirmed_email_at, :public_name,
-                  :birth_date, :account_type
+                  :birth_date, :account_type, :mail_marketing_users_attributes
 
   attr_accessor :publishing_project, :publishing_user_settings, :publishing_user_about, :reseting_password
 
@@ -98,6 +98,7 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: ->(x) { x['link'].blank? }
   accepts_nested_attributes_for :bank_account, allow_destroy: true, reject_if: ->(attr) { attr[:bank_id].blank? }
   accepts_nested_attributes_for :category_followers, allow_destroy: true
+  accepts_nested_attributes_for :mail_marketing_users, allow_destroy: true
 
   scope :with_permalink, -> { where.not(permalink: nil) }
   scope :active, -> { where(deactivated_at: nil) }

--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -23,6 +23,8 @@ class UserObserver < ActiveRecord::Observer
       FbPageCollectorWorker.perform_async(user.id)
     end
 
-    SendgridSyncWorker.perform_async(user.id) if user.newsletter_changed?
+    if user.newsletter_changed? || user.mail_marketing_users.present?
+      SendgridSyncWorker.perform_async(user.id)
+    end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -52,6 +52,7 @@ class UserPolicy < ApplicationPolicy
     u_attrs << record.attribute_names.map(&:to_sym) if record.is_a?(User)
     u_attrs << { links_attributes: %i[id _destroy link] }
     u_attrs << { category_followers_attributes: %i[id user_id category_id] }
+    u_attrs << { mail_marketing_users_attributes: %i[id _destroy mail_marketing_list_id] }
     u_attrs = u_attrs.flatten.uniq
 
     unless user.try(:admin?)

--- a/db/migrate/20170823111233_create_mail_marketing_lists.rb
+++ b/db/migrate/20170823111233_create_mail_marketing_lists.rb
@@ -1,0 +1,14 @@
+class CreateMailMarketingLists < ActiveRecord::Migration
+  def change
+    create_table :mail_marketing_lists do |t|
+      t.string :provider, null: false
+      t.string :label, null: false
+      t.string :list_id, null: false, foreign_key: false
+
+      t.timestamps null: false
+    end
+
+    add_index :mail_marketing_lists, [:provider, :list_id], unique: true
+    add_index :mail_marketing_lists, [:provider, :label], unique: true
+  end
+end

--- a/db/migrate/20170823120039_create_mail_marketing_users.rb
+++ b/db/migrate/20170823120039_create_mail_marketing_users.rb
@@ -1,0 +1,13 @@
+class CreateMailMarketingUsers < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+    create_table :mail_marketing_users do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :mail_marketing_list, index: true, foreign_key: true
+      t.uuid :unsubcribe_token, null: false, default: 'uuid_generate_v4()'
+      t.timestamp :last_sync_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170825120936_adjusts_on_mail_marketing_lists.rb
+++ b/db/migrate/20170825120936_adjusts_on_mail_marketing_lists.rb
@@ -1,0 +1,6 @@
+class AdjustsOnMailMarketingLists < ActiveRecord::Migration
+  def change
+    add_column :mail_marketing_lists, :disabled_at, :datetime
+    add_column :mail_marketing_lists, :provider_data, :jsonb
+  end
+end

--- a/db/migrate/20170825121416_mail_marketing_lists_to_api.rb
+++ b/db/migrate/20170825121416_mail_marketing_lists_to_api.rb
@@ -1,0 +1,25 @@
+class MailMarketingListsToApi < ActiveRecord::Migration
+  def up
+    execute %Q{
+create or replace view "1".mail_marketing_lists as 
+    select
+        mml.id as id,
+        mmu.user_id as user_id,
+        mml.provider as provider,
+        mml.label as label,
+        mml.list_id as list_id
+    from public.mail_marketing_users mmu
+        join public.mail_marketing_lists mml on mml.id = mmu.mail_marketing_list_id
+    where public.is_owner_or_admin(mmu.user_id) and mml.disabled_at is null;
+grant select on public.mail_marketing_lists to admin, web_user;
+grant select on public.mail_marketing_users to admin, web_user;
+grant select on "1".mail_marketing_lists to admin, web_user;
+}
+  end
+
+  def down
+    execute %Q{
+drop view "1".mail_marketing_lists;
+}
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -257,6 +257,37 @@ RSpec.describe UsersController, type: :controller do
       it { is_expected.to redirect_to edit_user_path(user) }
     end
 
+    context 'with mail marteking attributes' do
+      let!(:marketing_list) { create(:mail_marketing_list) }
+      let!(:marketing_list_current) { create(:mail_marketing_list) }
+      let!(:marketing_user) { create(:mail_marketing_user, mail_marketing_list: marketing_list_current, user: user) }
+
+      before do
+        put :update, id: user.id, locale: 'pt', user: {
+          mail_marketing_users_attributes: [
+            { mail_marketing_list_id: marketing_list.id },
+            { id: marketing_user.id, "_destroy": '1'}
+          ]
+        }
+      end
+
+      it "should in new list" do
+        expect(
+          user.mail_marketing_users
+          .where(mail_marketing_list_id: marketing_list.id)
+          .exists?
+        ).to eq(true)
+      end
+
+      it "should be removed from list check for destroy" do
+        expect(
+          user.mail_marketing_users
+          .where(mail_marketing_list_id: marketing_list_current.id)
+          .exists?
+        ).to eq(false)
+      end
+    end
+
     context 'removing category followers' do
       let(:project) { create(:project, state: 'successful') }
       before do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -375,4 +375,19 @@ FactoryGirl.define do
     destination 'all'
     value 20
   end
+
+  factory :mail_marketing_list do |f|
+    f.provider 'sendgrid'
+    sequence :label do |n|
+      "label_#{n}"
+    end
+    sequence :list_id do |n|
+      "list_#{n}"
+    end
+  end
+
+  factory :mail_marketing_user do |f|
+    f.association :user
+    f.association :mail_marketing_list
+  end
 end

--- a/spec/models/mail_marketing_list_spec.rb
+++ b/spec/models/mail_marketing_list_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MailMarketingList, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/mail_marketing_user_spec.rb
+++ b/spec/models/mail_marketing_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MailMarketingUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/mail_marketing_user_spec.rb
+++ b/spec/models/mail_marketing_user_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe MailMarketingUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'after destroy' do
+    let(:marketing_user) { create(:mail_marketing_user, user: create(:user)) }
+
+    before do
+      expect(SendgridSyncWorker).to receive(:perform_async).with(marketing_user.user_id, marketing_user.mail_marketing_list_id)
+    end
+
+    it 'should call sendgrid worker after destroy' do
+      marketing_user.destroy
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many :project_posts }
     it { is_expected.to have_many :unsubscribes }
     it { is_expected.to have_many :authorizations }
+    it { is_expected.to have_many :balance_transactions }
+    it { is_expected.to have_many :mail_marketing_users }
     it { is_expected.to have_one :user_total }
     it { is_expected.to have_one :bank_account }
   end

--- a/spec/workers/sendgrid_sync_worker_spec.rb
+++ b/spec/workers/sendgrid_sync_worker_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe SendgridSyncWorker do
     )
   end
 
+  let!(:newsletter_list) do
+    MailMarketingList.create(
+      provider: 'sendgrid',
+      list_id: 'xsb',
+      label: 'newsletter'
+    )
+  end
+
+  let!(:another_campaign) do
+    MailMarketingList.create(
+      provider: 'sendgrid',
+      list_id: 'xsb2',
+      label: 'another_campaign'
+    )
+  end
+
   before do
     CatarseSettings[:sendgrid_mkt_api_key] = 'key'
     Sidekiq::Testing.inline!
@@ -64,7 +80,7 @@ RSpec.describe SendgridSyncWorker do
     context 'when user want receive newsletter' do
       before do
         user.update_column(:newsletter, true)
-        expect(subject).to receive(:put_on_newsletter)
+        expect(subject).to receive(:put_on_list).with(newsletter_list.list_id)
       end
 
       it { subject.perform(user.id) }
@@ -73,7 +89,7 @@ RSpec.describe SendgridSyncWorker do
     context 'when user dont want receive newsltter' do
       before do
         user.update_column(:newsletter, false)
-        expect(subject).to receive(:remove_from_newsletter)
+        expect(subject).to receive(:remove_from_list).with(newsletter_list.list_id)
       end
 
       it { subject.perform(user.id) }


### PR DESCRIPTION
Better integration with sendgrid mail marketing api with:
- Added MailMarketingUser to map user -> lists
- Added MailMarketingList to map with lists should be avaiable
- Adjust POST /subscribe_newsletter to receive an list_id and subscribe email to a dynamic list
- Added MailMarketingLists to api endpoint in user context