### PR TITLE
Should not sent project_canceled for failed projects

### DIFF
--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -58,7 +58,7 @@ class ProjectObserver < ActiveRecord::Observer
 
   def from_online_to_rejected(project)
     refund_all_payments(project)
-    project.notify_owner(:project_canceled)
+    project.notify_owner(:project_canceled) if project.rejected?
   end
   alias from_waiting_funds_to_rejected from_online_to_rejected
   alias from_waiting_funds_to_failed from_online_to_rejected

--- a/spec/observers/project_observer_spec.rb
+++ b/spec/observers/project_observer_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe ProjectObserver do
         Sidekiq::Testing.inline!
         contribution_invalid.user.bank_account.destroy
         project.update_attribute :online_days, 2
+        expect(project).not_to receive(:notify_owner).with(:project_canceled)
         expect(DirectRefundWorker).to receive(:perform_async).with(payment_valid.id)
         expect(DirectRefundWorker).to receive(:perform_async).with(payment_slip.id).and_call_original
         expect(BalanceTransaction).to receive(:insert_contribution_refund).with(payment_slip.contribution_id)


### PR DESCRIPTION
failed emails sent via rd integration