### PR TITLE
Dont finish projects when have cancelation request

### DIFF
--- a/app/state_machine/flex_project_machine.rb
+++ b/app/state_machine/flex_project_machine.rb
@@ -56,11 +56,11 @@ class FlexProjectMachine
 
     # Ensure that project has pending contributions before enter on waiting_funds
     guard_transition(to: :waiting_funds) do |project|
-      project.in_time_to_wait?
+      project.in_time_to_wait? && !project.project_cancelation.present?
     end
 
     guard_transition(to: finished_states) do |project|
-      !project.in_time_to_wait?
+      !project.in_time_to_wait? && !project.project_cancelation.present?
     end
 
     # Ensure that project has not more pending contributions

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -115,6 +115,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :project_cancelation do |f|
+    f.association :project
+  end
+
   factory :balance_transfer do |f|
     f.amount 50
     f.association :project

--- a/spec/state_machine/aon_project_machine_spec.rb
+++ b/spec/state_machine/aon_project_machine_spec.rb
@@ -510,6 +510,23 @@ RSpec.describe AonProjectMachine, type: :model do
           end
 
           context "can't go to successful" do
+            context 'when project have cancelation request' do
+              before do
+                create(:project_cancelation, project: project)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:failed, { to_state: 'failed' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:successful, { to_state: 'successful' }).and_return(false)
+              end
+
+              it { subject.finish }
+            end
+
             context 'when project still have pending contributions' do
               before do
                 allow(project).to receive(:in_time_to_wait?)
@@ -576,6 +593,23 @@ RSpec.describe AonProjectMachine, type: :model do
           end
 
           context "can't go to failed" do
+            context 'when project have cancelation request' do
+              before do
+                create(:project_cancelation, project: project)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:successful, { to_state: 'successful' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:failed, { to_state: 'failed' }).and_return(false)
+              end
+
+              it { subject.finish }
+            end
+
             context 'when project have pending contributions' do
               before do
                 allow(project).to receive(:in_time_to_wait?)
@@ -631,6 +665,25 @@ RSpec.describe AonProjectMachine, type: :model do
           end
 
           context "can't go to waiting_funds" do
+
+            context 'when project have cancelation request' do
+              before do
+                create(:project_cancelation, project: project)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:failed, { to_state: 'failed' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:successful, { to_state: 'successful' }).and_return(false)
+
+              end
+
+              it { subject.finish }
+            end
+
             context 'when project not have pending contributions' do
               before do
                 allow(project).to receive(:in_time_to_wait?)
@@ -672,6 +725,24 @@ RSpec.describe AonProjectMachine, type: :model do
           end
 
           context "can't go to successful" do
+
+            context 'when project have cancelation request' do
+              before do
+                create(:project_cancelation, project: project)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:failed, { to_state: 'failed' }).and_return(false)
+
+                expect(subject).to receive(:transition_to)
+                  .with(:successful, { to_state: 'successful' }).and_return(false)
+              end
+
+              it { subject.finish }
+            end
+
             context 'when project has pending contributions' do
               before do
                 allow(project).to receive(:in_time_to_wait?)

--- a/spec/state_machine/flex_project_machine_spec.rb
+++ b/spec/state_machine/flex_project_machine_spec.rb
@@ -204,10 +204,12 @@ RSpec.describe FlexProjectMachine, type: :model do
       before do
         create(:project_cancelation, project: flexible_project)
 
-        expect(subject).not_to receive(:transition_to)
-          .with(:waiting_funds, { to_state: 'waiting_funds' })
-        expect(subject).not_to receive(:transition_to)
-          .with(:successful, { to_state: 'successful' })
+        expect(subject).to receive(:transition_to)
+          .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(false)
+        expect(subject).to receive(:transition_to)
+          .with(:successful, { to_state: 'successful' }).and_return(false)
+        expect(subject).to receive(:transition_to)
+          .with(:failed, { to_state: 'failed' }).and_return(false)
       end
 
       it { subject.finish }

--- a/spec/state_machine/flex_project_machine_spec.rb
+++ b/spec/state_machine/flex_project_machine_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe FlexProjectMachine, type: :model do
         create(:project_cancelation, project: flexible_project)
 
         expect(subject).not_to receive(:transition_to)
-          .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(true)
+          .with(:waiting_funds, { to_state: 'waiting_funds' })
         expect(subject).not_to receive(:transition_to)
           .with(:successful, { to_state: 'successful' })
       end

--- a/spec/state_machine/flex_project_machine_spec.rb
+++ b/spec/state_machine/flex_project_machine_spec.rb
@@ -200,6 +200,19 @@ RSpec.describe FlexProjectMachine, type: :model do
         .and_return(true)
     end
 
+    context 'when have a cancelation request' do
+      before do
+        create(:project_cancelation, project: flexible_project)
+
+        expect(subject).not_to receive(:transition_to)
+          .with(:waiting_funds, { to_state: 'waiting_funds' }).and_return(true)
+        expect(subject).not_to receive(:transition_to)
+          .with(:successful, { to_state: 'successful' })
+      end
+
+      it { subject.finish }
+    end
+
     context "when can't go to successful" do
       before do
         allow(flexible_project).to receive(:in_time_to_wait?)


### PR DESCRIPTION
add guard state transition to check if project have a project_cancelation request before finish