### PR TITLE
Subscription project rejected and maybe finished status

### DIFF
--- a/app/models/common_wrapper.rb
+++ b/app/models/common_wrapper.rb
@@ -207,18 +207,18 @@ class CommonWrapper
     return common_id;
   end
 
-  def index_reward(resource)
-    unless resource.project.common_id.present?
-      resource.project.index_on_common
-      resource.project.reload
+  def cancel_project(resource)
+    unless resource.common_id.present?
+      resource.index_on_common
+      resource.reload
     end
 
     uri = services_endpoint[:project_service]
-    uri.path = '/rpc/reward'
+    uri.path = '/rpc/cancel_project'
     response = request(
       uri.to_s,
       body: {
-        data: resource.common_index.to_json
+        id: resource.common_id
       }.to_json,
       action: :post,
       current_ip: resource.project.user.current_sign_in_ip
@@ -229,13 +229,8 @@ class CommonWrapper
       common_id = json.try(:[], 'id')
     else
       Rails.logger.info(response.body)
-      common_id = find_reward(resource.id)
+      common_id = find_project(resource.id)
     end
-
-    resource.update_column(
-      :common_id,
-      (common_id.presence || resource.common_id)
-    )
 
     return common_id;
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -584,4 +584,13 @@ class Project < ActiveRecord::Base
 
     common_wrapper.index_project(self) if common_wrapper
   end
+
+  def common_cancel_project
+    unless user.common_id.present?
+      user.index_on_common
+      user.reload
+    end
+
+    common_wrapper.cancel_project(self) if common_wrapper
+  end
 end

--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -62,8 +62,12 @@ class ProjectObserver < ActiveRecord::Observer
   end
 
   def from_online_to_rejected(project)
-    refund_all_payments(project)
-    project.notify_owner(:project_canceled) if project.rejected?
+    refund_all_payments(project) unless project.is_sub?
+    if project.rejected?
+      project.notify_owner(:project_canceled)
+
+      project.common_cancel_project if project.is_sub?
+    end
   end
   alias from_waiting_funds_to_rejected from_online_to_rejected
   alias from_waiting_funds_to_failed from_online_to_rejected

--- a/app/state_machine/sub_project_machine.rb
+++ b/app/state_machine/sub_project_machine.rb
@@ -11,6 +11,7 @@ class SubProjectMachine
     state :draft, initial: true
     state :online
     state :deleted
+    state :rejected
 
     # this block receive all transition
     # definitions
@@ -60,7 +61,7 @@ class SubProjectMachine
   setup_machine do
     transition from: :deleted, to: %i[draft]
     transition from: :draft, to: %i[deleted online]
-    transition from: :online, to: %i[draft deleted ]
+    transition from: :online, to: %i[draft deleted rejected]
 
   end
 


### PR DESCRIPTION
-  Added wrapper to call cancel_project on common wrapper and turn project on common to rejected and cancel all subscriptions

TODO:
- Map refused to subscription projects
- Check on front end to not enable reactive subscription on refused projects