### PR TITLE
Add balance_expired event on balance

### DIFF
--- a/config/locales/catarse_bootstrap/views/users/show.pt.yml
+++ b/config/locales/catarse_bootstrap/views/users/show.pt.yml
@@ -21,6 +21,7 @@ pt:
         refund_contributions: 'Reembolso para apoiadores do projeto %{project_name}'
         contribution_chargedback: 'Contestação de apoio para o projeto %{project_name}'
         subscription_payment_chargedback: 'Contestação de apoio para o projeto %{project_name}'
+        balance_expired: "Reembolso expirado. Consulte <a target='__blank' href='https://suporte.catarse.me/hc/pt-br/articles/202365507-Regras-e-funcionamento-dos-reembolsos-estornos-cancelamentos'>nossa política de reembolso</a>"
       debit: 'Saída'
       credit: 'Entrada'
       totals: 'Saldo '

--- a/db/migrate/20180504183215_add_balance_expired_on_balance.rb
+++ b/db/migrate/20180504183215_add_balance_expired_on_balance.rb
@@ -1,0 +1,32 @@
+class AddBalanceExpiredOnBalance < ActiveRecord::Migration
+  def up
+    execute %Q{
+    create or replace function public.can_expire_on_balance(public.balance_transactions)
+        returns boolean
+            language sql
+                as $$
+                   select (case when $1.event_name = 'contribution_refund' and ($1.created_at + '90 days'::interval < now()) then
+                       not exists (select true from public.balance_transactions t
+                                                  where t.user_id=$1.user_id
+                                                      and t.id > $1.id
+                                                      and t.event_name in ('balance_transfer_request','balance_transfer_project')
+                                              ) 
+                       and not exists (
+                                       select true from public.balance_transactions t
+                                           where t.user_id = $1.user_id
+                                                              and t.contribution_id = $1.contribution_id
+                                                              and t.event_name = 'balance_expired'
+                                                  )
+                                      else false end);
+                                          $$;
+
+
+}
+  end
+
+  def down
+		execute %Q{
+			drop function public.can_expire_on_balance(public.balance_transactions);
+		}
+  end
+end

--- a/lib/tasks/balance_transaction.rake
+++ b/lib/tasks/balance_transaction.rake
@@ -1,0 +1,9 @@
+namespace :balance_transaction do
+  desc 'expire balance transactions that can be expired'
+  task expire_transactions: [:environment] do
+    BalanceTransaction.where("balance_transactions.can_expire_on_balance").find_each do |transaction|
+      Rails.logger.info("expiring balance transaction id #{transaction.id}")
+      BalanceTransaction.insert_balance_expired(transaction.id)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,7 @@ FactoryGirl.define do
   factory :balance_transaction do |f|
     f.association :user
     f.association :project
+    f.association :contribution
     f.amount 100
     f.event_name 'foo'
   end

--- a/spec/models/balance_transaction_spec.rb
+++ b/spec/models/balance_transaction_spec.rb
@@ -206,4 +206,105 @@ RSpec.describe BalanceTransaction, type: :model do
 
   end
 
+  describe 'insert_balance_expired' do
+    let!(:transaction) { create(:balance_transaction, event_name: 'contribution_refund', amount: 10.0, created_at: 91.days.ago) }
+
+    subject { BalanceTransaction.insert_balance_expired(transaction.id) }
+
+    context 'when balance transaction is not expired yet' do
+      it 'should generate a balance_expired event' do
+        expect(subject.event_name).to eq('balance_expired')
+        expect(subject.project_id).to eq(transaction.project_id)
+        expect(subject.user_id).to eq(transaction.user_id)
+        expect(subject.contribution_id).to eq(transaction.contribution_id)
+        expect(subject.amount).to eq(transaction.amount * -1)
+      end
+    end
+
+    context 'when already have a balance transfer events after balance created' do
+      before do
+        create(:balance_transaction, event_name: event_name, user_id: transaction.user_id)
+      end
+
+      context 'when have balance_transfer_request event' do
+        let(:event_name) { 'balance_transfer_request' }
+
+        it 'should not generate balance expired event' do
+          is_expected.to be_nil
+        end
+      end
+
+      context 'when have balance_transfer_project event' do
+        let(:event_name) { 'balance_transfer_project' }
+
+        it 'should not generate balance expired event' do
+          is_expected.to be_nil
+        end
+      end
+    end
+
+    context 'when balance transaction is not over 90 days created' do
+      let(:transaction) { create(:balance_transaction, event_name: 'contribution_refund', amount: 10.0, created_at: 10.days.ago) }
+      it 'should not generate a balance_expired event' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'when balance transaction already is expired' do
+      before do
+        BalanceTransaction.insert_balance_expired(transaction.id)
+      end
+
+      it 'should not create balance_expired event' do
+        is_expected.to be_nil
+      end
+    end
+  end
+
+  describe 'can_expire_on_balance?' do
+    let!(:transaction) { create(:balance_transaction, event_name: 'contribution_refund', amount: 10.0, created_at: 91.days.ago) }
+
+    subject { transaction.can_expire_on_balance? }
+
+    context 'when transaction already over 91 days' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when event is not contribution_refund' do
+      let!(:transaction) { create(:balance_transaction, event_name: 'catarse_contribution_fee', amount: 10.0, created_at: 91.days.ago) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when transaction is not over 91 days' do
+      let!(:transaction) { create(:balance_transaction, event_name: 'contribution_refund', amount: 10.0, created_at: 70.days.ago) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when transaction have any of balance_transfer events' do
+      before do
+        create(:balance_transaction, event_name: event_name, user_id: transaction.user_id)
+      end
+
+      context 'when have balance_transfer_request event' do
+        let(:event_name) { 'balance_transfer_request' }
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when have balance_transfer_project event' do
+        let(:event_name) { 'balance_transfer_project' }
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context 'when transaction already expired on balance' do
+      before do
+        create(:balance_transaction, event_name: 'balance_expired', contribution_id: transaction.contribution_id, user_id: transaction.user_id, project_id: transaction.project_id)
+      end
+
+      it 'should not create balance_expired event' do
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- Added function to database to check if a balance_transaction (contribution_refund) can be expired
- Added method on BalanceTransaction to insert balance_expired event
- add task to expire all balance transaction events that can be expired 