### PR TITLE
README: Corrected versions of PostgRest & Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ The official repo is https://github.com/catarse/catarse
 
 To run this project you need to have:
 
-* Ruby 2.4.1
+* Ruby 2.4.4
 
 * Rails 4.2
 
-* [postgREST 0.3](https://github.com/begriffs/postgrest/releases/tag/v0.3.0.3)
+* [postgREST 0.3](https://github.com/begriffs/postgrest/releases/tag/v0.3.2.0)
 
 * [PostgreSQL 9.4](http://www.postgresql.org/)
   * OSX - [Postgres.app](http://postgresapp.com/)


### PR DESCRIPTION
Previous version of postgrest (0.3.0.3) does not support `limit` and `pagination` but we are using these parameters in new changes.
Also Ruby version is 2.4.4 in Gemfile, so corrected that as well.